### PR TITLE
Immunefi 11461

### DIFF
--- a/.deployments/rinkeby/rinkeby-1655752033.json
+++ b/.deployments/rinkeby/rinkeby-1655752033.json
@@ -1,0 +1,53 @@
+{
+  "CallWhitelist": {
+    "contractAddress": "0xEd2719678d589bd01A276e593EEA7C4c67cD551D",
+    "contractImplementationAddress": "",
+    "constructorArgs": []
+  },
+  "AssetVault": {
+    "contractAddress": "0xf91C5d58116E37DeBfa8785Fec5e838C8c9A2e67",
+    "contractImplementationAddress": "",
+    "constructorArgs": []
+  },
+  "VaultFactory": {
+    "contractAddress": "0x352edb9a6983a16B9757d2b7742a53c3Fc597117",
+    "contractImplementationAddress": "0x3DC7cAE7086F7Ef3002cd452e7D81B6109d0F0fD",
+    "constructorArgs": []
+  },
+  "FeeController": {
+    "contractAddress": "0xDe5Ef1dB67083c78dD3b6D98cD5453c56eF66b27",
+    "contractImplementationAddress": "",
+    "constructorArgs": []
+  },
+  "BorrowerNote": {
+    "contractAddress": "0xC93d6Bdc878306D69657D4d472505CC34D717B87",
+    "constructorArgs": [
+      "Arcade.xyz BorrowerNote",
+      "aBN"
+    ]
+  },
+  "LenderNote": {
+    "contractAddress": "0x05A8c1cF44714ebE41482505EC0c11548fFf599A",
+    "constructorArgs": [
+      "Arcade.xyz LenderNote",
+      "aLN"
+    ]
+  },
+  "LoanCore": {
+    "contractAddress": "0x27315f3149861967a68F3f829782b59d2Bd12c5a",
+    "contractImplementationAddress": "0xFe93470980E920C4237d14950B6c3573f5e9914e",
+    "constructorArgs": []
+  },
+  "RepaymentController": {
+    "contractAddress": "0xcD8c971597aB5a63082ba8C59a1DE6378e7582e5",
+    "contractImplementationAddress": "",
+    "constructorArgs": [
+      "0x27315f3149861967a68F3f829782b59d2Bd12c5a"
+    ]
+  },
+  "OriginationController": {
+    "contractAddress": "0x40D4423c257E16d74aa85b621A16C524Ee59A496",
+    "contractImplementationAddress": "0xf22aA781232B9A6da7c8b96b22337a33A89b5ad9",
+    "constructorArgs": []
+  }
+}

--- a/contracts/OriginationController.sol
+++ b/contracts/OriginationController.sol
@@ -38,7 +38,8 @@ import {
     OC_NumberInstallments,
     OC_SignatureIsExpired,
     OC_RolloverCurrencyMismatch,
-    OC_RolloverCollateralMismatch
+    OC_RolloverCollateralMismatch,
+    OC_SideMismatch
 } from "./errors/Lending.sol";
 
 /**
@@ -168,7 +169,6 @@ contract OriginationController is
         uint160 nonce
     ) public override returns (uint256 loanId) {
         _validateLoanTerms(loanTerms);
-
         // Determine if signature needs to be on the borrow or lend side
         Side neededSide = isSelfOrApproved(borrower, _msgSender()) ? Side.LEND : Side.BORROW;
 
@@ -697,10 +697,25 @@ contract OriginationController is
         bytes32 sighash,
         Side neededSide
     ) internal view {
-        if (caller == signer) revert OC_ApprovedOwnLoan(caller);
-
         address shouldBeSigner = neededSide == Side.LEND ? lender : borrower;
         address shouldBeCaller = shouldBeSigner == lender ? borrower : lender;
+
+        //checks for signature side wrt to signer
+        if (signer == borrower && neededSide == Side.LEND) {
+            revert OC_SideMismatch(signer, Side.LEND);
+        } else if (signer == lender && neededSide == Side.BORROW) {
+           revert OC_SideMismatch(signer, Side.BORROW);
+        } else if (isSelfOrApproved(shouldBeCaller, caller) && shouldBeCaller == borrower) {
+            if (neededSide == Side.BORROW) {
+               revert OC_SideMismatch(shouldBeCaller, neededSide);
+            }
+        } else if (isSelfOrApproved(shouldBeCaller, caller) && shouldBeCaller == lender) {
+           if (neededSide == Side.LEND) {
+               revert OC_SideMismatch(shouldBeCaller, neededSide);
+           }
+        }
+
+        if (caller == signer) revert OC_ApprovedOwnLoan(caller);
 
         if (!isSelfOrApproved(shouldBeCaller, caller) && !isApprovedForContract(shouldBeCaller, sig, sighash)) {
             revert OC_CallerNotParticipant(msg.sender);

--- a/contracts/errors/Lending.sol
+++ b/contracts/errors/Lending.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.11;
 
 import "../libraries/LoanLibrary.sol";
+import "../interfaces/IOriginationController.sol";
 
 /**
  * @title LendingErrors
@@ -140,6 +141,14 @@ error OC_RolloverCollateralMismatch(
     address newCollateralAddress,
     uint256 newCollateralId
 );
+
+/**
+ * @notice New currency does not match for a loan rollover request.
+ *
+ * @param signer                       The address of the external signer.
+ * @param side                         The side of the loan being signed.
+ */
+error OC_SideMismatch(address signer, IOriginationController.Side side);
 
 // ==================================== ITEMS VERIFIER ======================================
 /// @notice All errors prefixed with IV_, to separate from other contracts in the protocol.

--- a/test/OriginationController.ts
+++ b/test/OriginationController.ts
@@ -543,6 +543,32 @@ describe("OriginationController", () => {
                 .withArgs(await lender.getAddress(), originationController.address, loanTerms.principal);
         });
 
+        it("it does not allow a mismatch between signer and loan side", async () => {
+            const { originationController, mockERC20, vaultFactory, user: lender, other: borrower } = ctx;
+
+            const bundleId = await initializeBundle(vaultFactory, borrower);
+            const loanTerms = createLoanTerms(mockERC20.address, vaultFactory.address, { collateralId: bundleId });
+            await mint(mockERC20, lender, loanTerms.principal);
+
+            const sig = await createLoanTermsSignature(
+                originationController.address,
+                "OriginationController",
+                loanTerms,
+                borrower,
+                "2",
+                1,
+                "l",
+            );
+
+            await approve(mockERC20, lender, originationController.address, loanTerms.principal);
+            await vaultFactory.connect(borrower).approve(originationController.address, bundleId);
+            await expect(
+                originationController
+                    .connect(borrower)
+                    .initializeLoan(loanTerms, await borrower.getAddress(), await lender.getAddress(), sig, 1),
+            ).to.be.revertedWith("SideMismatch");
+        });
+
         it("Initializes a loan with unbundled collateral", async () => {
             const { originationController, mockERC20, mockERC721, user: lender, other: borrower } = ctx;
 
@@ -607,6 +633,72 @@ describe("OriginationController", () => {
             ).to.be.revertedWith("LC_NonceUsed");
         });
 
+        //////////////////////// TODO: REMOVE IF KEVIN OK ////////////////////
+        /////////////////////////////////////////////////////////////////////
+        xit("it does not allow a mismatch between signer and loan side when a party is a contract", async () => {
+            // Deploy an ERC-1271 to act as the lender
+            const {
+                originationController,
+                mockERC20,
+                vaultFactory,
+                user: lender,
+                other: borrower,
+                signers: signers,
+            } = ctx;
+            const lenderContract = <ERC1271LenderMock>await deploy("ERC1271LenderMock", lender, []);
+            const attacker = signers[1];
+
+            // Lender signs a borrow against a collateral, with convenient terms for the borrower
+            const bundleId = await initializeBundle(vaultFactory, lender);
+
+            const borrowerLoanTerms = createLoanTerms(mockERC20.address, vaultFactory.address, {
+                collateralId: bundleId,
+            });
+
+            // The lender signed a borrow signature
+            const sig = await createLoanTermsSignature(
+                originationController.address,
+                "OriginationController",
+                borrowerLoanTerms,
+                lender,
+                "2",
+                1,
+                "b",
+            );
+
+            // Lender is also willing to lend, with worse terms for the borrower and better terms for the lender
+            const lenderLoanTerms = createLoanTerms(mockERC20.address, vaultFactory.address, {
+                collateralId: bundleId,
+            });
+
+            await mint(mockERC20, lender, lenderLoanTerms.principal);
+            await mockERC20.connect(lender).transfer(lenderContract.address, lenderLoanTerms.principal);
+            await lenderContract.approve(mockERC20.address, originationController.address);
+            // No approval for origination - OC will check ERC-1271
+
+            await approve(mockERC20, lender, originationController.address, lenderLoanTerms.principal);
+
+            // The borrower buys the NFT from the lender
+            await vaultFactory
+                .connect(lender)
+                .transferFrom(await lender.getAddress(), await borrower.getAddress(), bundleId);
+
+            // The borrower want to borrow against that collateral with good terms for the borrower, that the lender didn't agree to as a lender
+            await vaultFactory.connect(borrower).approve(originationController.address, bundleId);
+
+            await expect(originationController.connect(borrower).approve(await lender.getAddress(), true))
+                .to.emit(originationController, "Approval")
+                .withArgs(borrower.address, await lender.getAddress(), true);
+
+            expect(await originationController.isApproved(await borrower.getAddress(), await lender.getAddress())).to.be
+                .true;
+
+            await expect(
+                originationController
+                    .connect(attacker)
+                    .initializeLoan(borrowerLoanTerms, await borrower.getAddress(), lenderContract.address, sig, 1),
+            ).to.be.revertedWith("OC_SideMismatch");
+        });
         describe("initializeLoanWithCollateralPermit", () => {
             it("Reverts if the collateral does not support permit", async () => {
                 const {

--- a/test/Rollovers.ts
+++ b/test/Rollovers.ts
@@ -361,7 +361,7 @@ describe("Rollovers", () => {
                 lender,
                 "2",
                 2,
-                "b",
+                "l",
             );
 
             await expect(


### PR DESCRIPTION
Added require statements in `originationController initializeLoan()` function to ensure that the signer and the side in the signature match.
Created test in `originationController.ts` to confirm that the code will revert if there is a mismatch between signer and side.

To run the `originationController.ts` tests:
`npx hardhat test test/OriginationController.ts`

To run the entire test suite use:
`npx hardhat test `