### PR TITLE
(fix-immunefi-11461): pre-rebase commit

### DIFF
--- a/contracts/errors/Lending.sol
+++ b/contracts/errors/Lending.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.11;
 
 import "../libraries/LoanLibrary.sol";
+import "../interfaces/IOriginationController.sol";
 
 /**
  * @title LendingErrors
@@ -140,6 +141,14 @@ error OC_RolloverCollateralMismatch(
     address newCollateralAddress,
     uint256 newCollateralId
 );
+
+/**
+ * @notice New currency does not match for a loan rollover request.
+ *
+ * @param signer                       The address of the external signer.
+ * @param side                         The side of the loan being signed.
+ */
+error OC_SideMismatch(address signer, IOriginationController.Side side);
 
 // ==================================== ITEMS VERIFIER ======================================
 /// @notice All errors prefixed with IV_, to separate from other contracts in the protocol.

--- a/test/Rollovers.ts
+++ b/test/Rollovers.ts
@@ -361,7 +361,7 @@ describe("Rollovers", () => {
                 lender,
                 "2",
                 2,
-                "b",
+                "l",
             );
 
             await expect(


### PR DESCRIPTION
Added logic in `originationController``_validateCounterparties()` function to ensure that the signer and the side in the signature match.
Created test in `originationController.ts` to confirm that the code will revert with a custom error if there is a mismatch between signer and side.

To run the `originationController.ts` tests:
`npx hardhat test test/OriginationController.ts`

To run the entire test suite use:
`npx hardhat test`

Re. repurposing the `Attack.sol` test and having it fail in `OriginationController.ts` because of the `immunefi-11461` fix:
This test will not fail after fixing the bug because of its socially engineered flow:

- the signature is [created](https://github.com/arcadexyz/v2-contracts/blob/980d793682fee9e9a139b54d94b0bca1a789ae35/test/Attack.ts#L178) by the lender and specifies the borrower for `Side`
- the vault is initialized by the lender and is [transferred](https://github.com/arcadexyz/v2-contracts/blob/980d793682fee9e9a139b54d94b0bca1a789ae35/test/Attack.ts#L190) to the borrower
- borrower approves bundleId of aforementioned vault to originationController
- borrower gives [approve](https://github.com/arcadexyz/v2-contracts/blob/980d793682fee9e9a139b54d94b0bca1a789ae35/test/Attack.ts#L195) to lender to sign and initialize loans on their behalf -- hence the signature created by the lender, specifying the Borrow as side is OK because of this approve
- [initializeLoan](https://github.com/arcadexyz/v2-contracts/blob/980d793682fee9e9a139b54d94b0bca1a789ae35/test/Attack.ts#L205) is run and `_validateCounterparties()` is called, where `Side` was set to `B` by the lender but the borrower sanctioned them to do so with the `approve`, so no `revert` occurs.

I think we should remove this test. It is too much of an edge case (it is currently in `OriginationController.ts` but is skipped. ).
@kkennis Do you agree on this issue?
