### PR TITLE
Add system for reporting vault inventory and depositing with reporting

### DIFF
--- a/contracts/interfaces/IVaultDepositRouter.sol
+++ b/contracts/interfaces/IVaultDepositRouter.sol
@@ -11,15 +11,26 @@ interface IVaultDepositRouter {
 
     // ============= Errors ==============
 
-    error VDR_NotOwner(address vault, address caller);
+    error VDR_ZeroAddress();
+    error VDR_InvalidVault(address vault);
+    error VDR_NotOwnerOrApproved(address vault, address caller);
+    error VDR_BatchLengthMismatch();
 
     // ================ Deposit Operations ================
 
     function depositERC20(address vault, address token, uint256 amount) external;
 
+    function depositERC20Batch(address vault, address[] calldata tokens, uint256[] calldata amounts) external;
+
     function depositERC721(address vault, address token, uint256 id) external;
+
+    function depositERC721Batch(address vault, address[] calldata tokens, uint256[] calldata ids) external;
 
     function depositERC1155(address vault, address token, uint256 id, uint256 amount) external;
 
+    function depositERC1155Batch(address vault, address[] calldata tokens, uint256[] calldata ids, uint256[] calldata amounts) external;
+
     function depositPunk(address vault, address token, uint256 id) external;
+
+    function depositPunkBatch(address vault, address[] calldata tokens, uint256[] calldata ids) external;
 }

--- a/contracts/interfaces/IVaultDepositRouter.sol
+++ b/contracts/interfaces/IVaultDepositRouter.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.11;
+
+interface IVaultDepositRouter {
+    // ============= Events ==============
+
+    event ERC20Deposit(address indexed vault, address indexed token, uint256 amount);
+    event ERC721Deposit(address indexed vault, address indexed token, uint256 id);
+    event ERC1155Deposit(address indexed vault, address indexed token, uint256 id, uint256 amount);
+
+    // ============= Errors ==============
+
+    error VDR_NotOwner(address vault, address caller);
+
+    // ================ Deposit Operations ================
+
+    function depositERC20(address vault, address token, uint256 amount) external;
+
+    function depositERC721(address vault, address token, uint256 id) external;
+
+    function depositERC1155(address vault, address token, uint256 id, uint256 amount) external;
+
+    function depositPunk(address vault, address token, uint256 id) external;
+}

--- a/contracts/interfaces/IVaultDepositRouter.sol
+++ b/contracts/interfaces/IVaultDepositRouter.sol
@@ -3,12 +3,6 @@
 pragma solidity ^0.8.11;
 
 interface IVaultDepositRouter {
-    // ============= Events ==============
-
-    event ERC20Deposit(address indexed vault, address indexed token, uint256 amount);
-    event ERC721Deposit(address indexed vault, address indexed token, uint256 id);
-    event ERC1155Deposit(address indexed vault, address indexed token, uint256 id, uint256 amount);
-
     // ============= Errors ==============
 
     error VDR_ZeroAddress();

--- a/contracts/interfaces/IVaultInventoryReporter.sol
+++ b/contracts/interfaces/IVaultInventoryReporter.sol
@@ -49,6 +49,8 @@ interface IVaultInventoryReporter {
 
     function enumerate(address vault) external view returns (Item[] memory);
 
+    function enumerateOrFail(address vault) external view returns (Item[] memory);
+
     function keys(address vault) external view returns (bytes32[] memory);
 
     function keyAtIndex(address vault, uint256 index) external view returns (bytes32);

--- a/contracts/interfaces/IVaultInventoryReporter.sol
+++ b/contracts/interfaces/IVaultInventoryReporter.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.11;
+
+interface IVaultInventoryReporter {
+    // ============= Events ==============
+
+    event Registered(address indexed vault, address indexed reporter, bytes32 itemsHash);
+
+    // ============= Data Types ==============
+
+    enum ItemType {
+        ERC_721,
+        ERC_1155,
+        ERC_20
+    }
+
+    struct Item {
+        ItemType itemType;
+        address tokenAddress;
+        uint256 tokenId;                // Not used for ERC20 items - will be ignored
+        uint256 tokenAmount;            // Not used for ERC721 items - will be ignored
+    }
+
+    // ================ Inventory Operations ================
+
+    function add(address vault, Item[] calldata items) external;
+
+    function remove(address vault, Item[] calldata items) external;
+
+    function clear(address vault) external;
+
+    // ================ Verification ================
+
+    function verify(address vault) external view returns (bool);
+
+    function verifyItem(address vault, Item calldata item) external view returns (bool);
+
+    // ================ Enumeration ================
+
+    function enumerate(address vault) external view returns (Item[] memory);
+
+    function keys(address vault) external view returns (bytes32[] memory);
+
+    function keyAtIndex(address vault, uint256 index) external view returns (bytes32);
+
+    function itemAtIndex(address vault, uint256 index) external view returns (Item memory);
+}

--- a/contracts/interfaces/IVaultInventoryReporter.sol
+++ b/contracts/interfaces/IVaultInventoryReporter.sol
@@ -9,6 +9,7 @@ interface IVaultInventoryReporter {
     event Remove(address indexed vault, address indexed reporter, bytes32 itemHash);
     event Clear(address indexed vault, address indexed reporter);
     event SetApproval(address indexed vault, address indexed target);
+    event SetGlobalApproval(address indexed target, bool isApproved);
 
     // ============= Errors ==============
 
@@ -107,4 +108,8 @@ interface IVaultInventoryReporter {
     function setApproval(address vault, address target) external;
 
     function isOwnerOrApproved(address vault, address target) external view returns (bool);
+
+    function setGlobalApproval(address caller, bool isApproved) external;
+
+    function isGloballyApproved(address target) external view returns (bool);
 }

--- a/contracts/interfaces/IVaultInventoryReporter.sol
+++ b/contracts/interfaces/IVaultInventoryReporter.sol
@@ -18,6 +18,8 @@ interface IVaultInventoryReporter {
     error VIR_NotVerified(address vault, uint256 itemIndex);
     error VIR_NotInInventory(address vault, bytes32 itemHash);
     error VIR_NotApproved(address vault, address target);
+    error VIR_PermitDeadlineExpired(uint256 deadline);
+    error VIR_InvalidPermitSignature(address signer);
 
     // ============= Data Types ==============
 
@@ -42,6 +44,45 @@ interface IVaultInventoryReporter {
     function remove(address vault, Item[] calldata items) external;
 
     function clear(address vault) external;
+
+    function addWithPermit(
+        address vault,
+        Item[] calldata items,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    function removeWithPermit(
+        address vault,
+        Item[] calldata items,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    function clearWithPermit(
+        address vault,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    function permit(
+        address owner,
+        address target,
+        address vault,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    // solhint-disable-next-line func-name-mixedcase
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
 
     // ================ Verification ================
 

--- a/contracts/interfaces/IVaultInventoryReporter.sol
+++ b/contracts/interfaces/IVaultInventoryReporter.sol
@@ -5,7 +5,9 @@ pragma solidity ^0.8.11;
 interface IVaultInventoryReporter {
     // ============= Events ==============
 
-    event Registered(address indexed vault, address indexed reporter, bytes32 itemsHash);
+    event Add(address indexed vault, address indexed reporter, bytes32 itemHash);
+    event Remove(address indexed vault, address indexed reporter, bytes32 itemHash);
+    event Clear(address indexed vault, address indexed reporter);
 
     // ============= Errors ==============
 

--- a/contracts/interfaces/IVaultInventoryReporter.sol
+++ b/contracts/interfaces/IVaultInventoryReporter.sol
@@ -7,6 +7,14 @@ interface IVaultInventoryReporter {
 
     event Registered(address indexed vault, address indexed reporter, bytes32 itemsHash);
 
+    // ============= Errors ==============
+
+    error VIR_NoItems();
+    error VIR_TooManyItems(uint256 maxItems);
+    error VIR_InvalidRegistration(address vault, uint256 itemIndex);
+    error VIR_NotVerified(address vault, uint256 itemIndex);
+    error VIR_NotInInventory(address vault, bytes32 itemHash);
+
     // ============= Data Types ==============
 
     enum ItemType {

--- a/contracts/interfaces/IVaultInventoryReporter.sol
+++ b/contracts/interfaces/IVaultInventoryReporter.sol
@@ -20,7 +20,8 @@ interface IVaultInventoryReporter {
     enum ItemType {
         ERC_721,
         ERC_1155,
-        ERC_20
+        ERC_20,
+        PUNKS
     }
 
     struct Item {

--- a/contracts/interfaces/IVaultInventoryReporter.sol
+++ b/contracts/interfaces/IVaultInventoryReporter.sol
@@ -8,6 +8,7 @@ interface IVaultInventoryReporter {
     event Add(address indexed vault, address indexed reporter, bytes32 itemHash);
     event Remove(address indexed vault, address indexed reporter, bytes32 itemHash);
     event Clear(address indexed vault, address indexed reporter);
+    event SetApproval(address indexed vault, address indexed target);
 
     // ============= Errors ==============
 
@@ -16,6 +17,7 @@ interface IVaultInventoryReporter {
     error VIR_InvalidRegistration(address vault, uint256 itemIndex);
     error VIR_NotVerified(address vault, uint256 itemIndex);
     error VIR_NotInInventory(address vault, bytes32 itemHash);
+    error VIR_NotApproved(address vault, address target);
 
     // ============= Data Types ==============
 
@@ -58,4 +60,10 @@ interface IVaultInventoryReporter {
     function keyAtIndex(address vault, uint256 index) external view returns (bytes32);
 
     function itemAtIndex(address vault, uint256 index) external view returns (Item memory);
+
+    // ================ Permissions ================
+
+    function setApproval(address vault, address target) external;
+
+    function isOwnerOrApproved(address vault, address target) external view returns (bool);
 }

--- a/contracts/vault/VaultDepositRouter.sol
+++ b/contracts/vault/VaultDepositRouter.sol
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.11;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import "../interfaces/IVaultDepositRouter.sol";
+import "../interfaces/IVaultInventoryReporter.sol";
+import "../interfaces/IVaultFactory.sol";
+import "../external/interfaces/IPunks.sol";
+
+/**
+ * @title VaultInventoryReporter
+ * @author Non-Fungible Technologies, Inc.
+ *
+ * The VaultInventoryReporter contract is a helper contract that
+ * works with Arcade asset vaults and the vault inventory reporter.
+ * By depositing to asset vaults by calling the functions in this contract,
+ * inventory registration will be automatically updated.
+ */
+contract VaultDepositRouter is IVaultDepositRouter {
+    using SafeERC20 for IERC20;
+
+    // ============================================ STATE ==============================================
+
+    // ============= Global Immutable State ==============
+
+    address public immutable factory;
+    IVaultInventoryReporter public immutable reporter;
+
+    // ========================================= CONSTRUCTOR ===========================================
+
+    constructor(address _factory, address _reporter) {
+        if (_factory == address(0)) revert VDR_ZeroAddress();
+        if (_reporter == address(0)) revert VDR_ZeroAddress();
+
+        factory = _factory;
+        reporter = IVaultInventoryReporter(_reporter);
+    }
+
+    // ====================================== DEPOSIT OPERATIONS ========================================
+
+    function depositERC20(
+        address vault,
+        address token,
+        uint256 amount
+    ) external override validate(vault, msg.sender) {
+        IERC20(token).safeTransferFrom(msg.sender, vault, amount);
+
+        IVaultInventoryReporter.Item[] memory items = new IVaultInventoryReporter.Item[](1);
+
+        items[0] = IVaultInventoryReporter.Item({
+            itemType: IVaultInventoryReporter.ItemType.ERC_20,
+            tokenAddress: token,
+            tokenId: 0,
+            tokenAmount: amount
+        });
+
+        reporter.add(vault, items);
+
+        // No events because both token and reporter will emit
+    }
+
+    function depositERC20Batch(
+        address vault,
+        address[] calldata tokens,
+        uint256[] calldata amounts
+    ) external override validate(vault, msg.sender) {
+        uint256 numItems = tokens.length;
+        if (numItems != amounts.length) revert VDR_BatchLengthMismatch();
+
+        IVaultInventoryReporter.Item[] memory items = new IVaultInventoryReporter.Item[](numItems);
+
+        for (uint256 i = 0; i < numItems; i++) {
+            address token = tokens[i];
+            uint256 amount = amounts[i];
+
+            IERC20(token).safeTransferFrom(msg.sender, vault, amount);
+
+            items[i] = IVaultInventoryReporter.Item({
+                itemType: IVaultInventoryReporter.ItemType.ERC_20,
+                tokenAddress: token,
+                tokenId: 0,
+                tokenAmount: amount
+            });
+        }
+
+        reporter.add(vault, items);
+
+        // No events because both token and reporter will emit
+    }
+
+    function depositERC721(
+        address vault,
+        address token,
+        uint256 id
+    ) external override validate(vault, msg.sender) {
+        IERC721(token).safeTransferFrom(msg.sender, vault, id);
+
+        IVaultInventoryReporter.Item[] memory items = new IVaultInventoryReporter.Item[](1);
+
+        items[0] = IVaultInventoryReporter.Item({
+            itemType: IVaultInventoryReporter.ItemType.ERC_721,
+            tokenAddress: token,
+            tokenId: id,
+            tokenAmount: 0
+        });
+
+        reporter.add(vault, items);
+
+        // No events because both token and reporter will emit
+    }
+
+    function depositERC721Batch(
+        address vault,
+        address[] calldata tokens,
+        uint256[] calldata ids
+    ) external override validate(vault, msg.sender) {
+        uint256 numItems = tokens.length;
+        if (numItems != ids.length) revert VDR_BatchLengthMismatch();
+
+        IVaultInventoryReporter.Item[] memory items = new IVaultInventoryReporter.Item[](numItems);
+
+        for (uint256 i = 0; i < numItems; i++) {
+            address token = tokens[i];
+            uint256 id = ids[i];
+
+            IERC721(token).safeTransferFrom(msg.sender, vault, id);
+
+            items[i] = IVaultInventoryReporter.Item({
+                itemType: IVaultInventoryReporter.ItemType.ERC_721,
+                tokenAddress: token,
+                tokenId: 0,
+                tokenAmount: id
+            });
+        }
+
+        reporter.add(vault, items);
+
+        // No events because both token and reporter will emit
+    }
+
+    function depositERC1155(
+        address vault,
+        address token,
+        uint256 id,
+        uint256 amount
+    ) external override validate(vault, msg.sender) {
+        IERC1155(token).safeTransferFrom(msg.sender, vault, id, amount, "");
+
+        IVaultInventoryReporter.Item[] memory items = new IVaultInventoryReporter.Item[](1);
+
+        items[0] = IVaultInventoryReporter.Item({
+            itemType: IVaultInventoryReporter.ItemType.ERC_1155,
+            tokenAddress: token,
+            tokenId: id,
+            tokenAmount: amount
+        });
+
+        reporter.add(vault, items);
+
+        // No events because both token and reporter will emit
+    }
+
+    function depositERC1155Batch(
+        address vault,
+        address[] calldata tokens,
+        uint256[] calldata ids,
+        uint256[] calldata amounts
+    ) external override validate(vault, msg.sender) {
+        uint256 numItems = tokens.length;
+        if (numItems != ids.length) revert VDR_BatchLengthMismatch();
+
+        IVaultInventoryReporter.Item[] memory items = new IVaultInventoryReporter.Item[](numItems);
+
+        for (uint256 i = 0; i < numItems; i++) {
+            address token = tokens[i];
+            uint256 id = ids[i];
+            uint256 amount = amounts[i];
+
+            IERC1155(token).safeTransferFrom(msg.sender, vault, id, amount, "");
+
+            items[i] = IVaultInventoryReporter.Item({
+                itemType: IVaultInventoryReporter.ItemType.ERC_1155,
+                tokenAddress: token,
+                tokenId: id,
+                tokenAmount: amount
+            });
+        }
+
+        reporter.add(vault, items);
+
+        // No events because both token and reporter will emit
+    }
+
+    function depositPunk(
+        address vault,
+        address token,
+        uint256 id
+    ) external override validate(vault, msg.sender) {
+        IPunks(token).buyPunk(id);
+        IPunks(token).transferPunk(vault, id);
+
+        IVaultInventoryReporter.Item[] memory items = new IVaultInventoryReporter.Item[](1);
+
+        items[0] = IVaultInventoryReporter.Item({
+            itemType: IVaultInventoryReporter.ItemType.PUNKS,
+            tokenAddress: token,
+            tokenId: id,
+            tokenAmount: 0
+        });
+
+        reporter.add(vault, items);
+
+        // No events because both token and reporter will emit
+    }
+
+    function depositPunkBatch(
+        address vault,
+        address[] calldata tokens,
+        uint256[] calldata ids
+    ) external override validate(vault, msg.sender) {
+        uint256 numItems = tokens.length;
+        if (numItems != ids.length) revert VDR_BatchLengthMismatch();
+
+        IVaultInventoryReporter.Item[] memory items = new IVaultInventoryReporter.Item[](numItems);
+
+        for (uint256 i = 0; i < numItems; i++) {
+            address token = tokens[i];
+            uint256 id = ids[i];
+
+            IPunks(token).buyPunk(id);
+            IPunks(token).transferPunk(vault, id);
+
+            items[i] = IVaultInventoryReporter.Item({
+                itemType: IVaultInventoryReporter.ItemType.PUNKS,
+                tokenAddress: token,
+                tokenId: 0,
+                tokenAmount: id
+            });
+        }
+
+        reporter.add(vault, items);
+
+        // No events because both token and reporter will emit
+    }
+
+    // ============================================ HELPERS =============================================
+
+    modifier validate(address vault, address caller) {
+        if (vault == address(0)) revert VDR_ZeroAddress();
+        if (!IVaultFactory(factory).isInstance(vault)) revert VDR_InvalidVault(vault);
+
+        uint256 tokenId = uint256(uint160(vault));
+        address owner = IERC721(factory).ownerOf(tokenId);
+
+        if (
+            caller != owner
+            && IERC721(factory).getApproved(tokenId) != caller
+            && !IERC721(factory).isApprovedForAll(owner, caller)
+        ) revert VDR_NotOwnerOrApproved(vault, caller);
+
+        _;
+    }
+
+
+}

--- a/contracts/vault/VaultDepositRouter.sol
+++ b/contracts/vault/VaultDepositRouter.sol
@@ -77,7 +77,7 @@ contract VaultDepositRouter is IVaultDepositRouter, VaultOwnershipChecker {
      * @notice Deposit multiple ERC20 tokens to the vault, registering inventory on the reporter
      *         simultaneously.
      *
-     * @param vault                         The vault to deposit to.
+     * @param vault                          The vault to deposit to.
      * @param tokens                         The tokens to deposit.
      * @param amounts                        The amount of tokens to deposit, for each token.
      */

--- a/contracts/vault/VaultDepositRouter.sol
+++ b/contracts/vault/VaultDepositRouter.sol
@@ -285,6 +285,56 @@ contract VaultDepositRouter is IVaultDepositRouter {
     // ============================================ HELPERS =============================================
 
     /**
+     * @dev Collect an ERC1155 from the caller, and return the Item struct.
+     *
+     * @param vault                         The vault to deposit to.
+     * @param token                         The token to deposit.
+     * @param id                            The ID of the token to deposit.
+     * @param amount                        The amount of tokens to deposit.
+     *
+     * @return item                         The Item struct for the asset collected.
+     */
+    function _depositERC1155(
+        address vault,
+        address token,
+        uint256 id,
+        uint256 amount
+    ) internal returns (IVaultInventoryReporter.Item memory) {
+        IERC1155(token).safeTransferFrom(msg.sender, vault, id, amount, "");
+
+        return IVaultInventoryReporter.Item({
+            itemType: IVaultInventoryReporter.ItemType.ERC_1155,
+            tokenAddress: token,
+            tokenId: id,
+            tokenAmount: amount
+        });
+    }
+
+    /**
+     * @dev Collect an ERC721 from the caller, and return the Item struct.
+     *
+     * @param vault                         The vault to deposit to.
+     * @param token                         The token to deposit.
+     * @param id                            The ID of the token to deposit.
+     *
+     * @return item                         The Item struct for the asset collected.
+     */
+    function _depositERC721(
+        address vault,
+        address token,
+        uint256 id
+    ) internal returns (IVaultInventoryReporter.Item memory) {
+        IERC721(token).safeTransferFrom(msg.sender, vault, id);
+
+        return IVaultInventoryReporter.Item({
+            itemType: IVaultInventoryReporter.ItemType.ERC_721,
+            tokenAddress: token,
+            tokenId: id,
+            tokenAmount: 0
+        });
+    }
+
+    /**
      * @dev Validates that the caller is allowed to deposit to the specified vault (owner or approved),
      *      and that the specified vault exists. Reverts on failed validation.
      *
@@ -306,37 +356,4 @@ contract VaultDepositRouter is IVaultDepositRouter {
 
         _;
     }
-
-    function _depositERC1155(
-        address vault,
-        address token,
-        uint256 id,
-        uint256 amount
-    ) internal returns (IVaultInventoryReporter.Item memory) {
-        IERC1155(token).safeTransferFrom(msg.sender, vault, id, amount, "");
-
-        return IVaultInventoryReporter.Item({
-            itemType: IVaultInventoryReporter.ItemType.ERC_1155,
-            tokenAddress: token,
-            tokenId: id,
-            tokenAmount: amount
-        });
-    }
-
-    function _depositERC721(
-        address vault,
-        address token,
-        uint256 id
-    ) internal returns (IVaultInventoryReporter.Item memory) {
-        IERC721(token).safeTransferFrom(msg.sender, vault, id);
-
-        return IVaultInventoryReporter.Item({
-            itemType: IVaultInventoryReporter.ItemType.ERC_721,
-            tokenAddress: token,
-            tokenId: id,
-            tokenAmount: 0
-        });
-    }
-
-
 }

--- a/contracts/vault/VaultDepositRouter.sol
+++ b/contracts/vault/VaultDepositRouter.sol
@@ -198,6 +198,8 @@ contract VaultDepositRouter is IVaultDepositRouter {
     ) external override validate(vault, msg.sender) {
         uint256 numItems = tokens.length;
         if (numItems != ids.length) revert VDR_BatchLengthMismatch();
+        if (numItems != amounts.length) revert VDR_BatchLengthMismatch();
+        if (ids.length != amounts.length) revert VDR_BatchLengthMismatch();
 
         IVaultInventoryReporter.Item[] memory items = new IVaultInventoryReporter.Item[](numItems);
 

--- a/contracts/vault/VaultDepositRouter.sol
+++ b/contracts/vault/VaultDepositRouter.sol
@@ -126,12 +126,7 @@ contract VaultDepositRouter is IVaultDepositRouter {
 
         IVaultInventoryReporter.Item[] memory items = new IVaultInventoryReporter.Item[](1);
 
-        items[0] = IVaultInventoryReporter.Item({
-            itemType: IVaultInventoryReporter.ItemType.ERC_721,
-            tokenAddress: token,
-            tokenId: id,
-            tokenAmount: 0
-        });
+        items[0] = _depositERC721(vault, token, id);
 
         reporter.add(vault, items);
 
@@ -157,17 +152,7 @@ contract VaultDepositRouter is IVaultDepositRouter {
         IVaultInventoryReporter.Item[] memory items = new IVaultInventoryReporter.Item[](numItems);
 
         for (uint256 i = 0; i < numItems; i++) {
-            address token = tokens[i];
-            uint256 id = ids[i];
-
-            IERC721(token).safeTransferFrom(msg.sender, vault, id);
-
-            items[i] = IVaultInventoryReporter.Item({
-                itemType: IVaultInventoryReporter.ItemType.ERC_721,
-                tokenAddress: token,
-                tokenId: 0,
-                tokenAmount: id
-            });
+            items[i] = _depositERC721(vault, tokens[i], ids[i]);
         }
 
         reporter.add(vault, items);
@@ -193,13 +178,7 @@ contract VaultDepositRouter is IVaultDepositRouter {
         IERC1155(token).safeTransferFrom(msg.sender, vault, id, amount, "");
 
         IVaultInventoryReporter.Item[] memory items = new IVaultInventoryReporter.Item[](1);
-
-        items[0] = IVaultInventoryReporter.Item({
-            itemType: IVaultInventoryReporter.ItemType.ERC_1155,
-            tokenAddress: token,
-            tokenId: id,
-            tokenAmount: amount
-        });
+        items[0] = _depositERC1155(vault, token, id, amount);
 
         reporter.add(vault, items);
 
@@ -328,7 +307,12 @@ contract VaultDepositRouter is IVaultDepositRouter {
         _;
     }
 
-    function _depositERC1155(address vault, address token, uint256 id, uint256 amount) internal returns (IVaultInventoryReporter.Item memory) {
+    function _depositERC1155(
+        address vault,
+        address token,
+        uint256 id,
+        uint256 amount
+    ) internal returns (IVaultInventoryReporter.Item memory) {
         IERC1155(token).safeTransferFrom(msg.sender, vault, id, amount, "");
 
         return IVaultInventoryReporter.Item({
@@ -336,6 +320,21 @@ contract VaultDepositRouter is IVaultDepositRouter {
             tokenAddress: token,
             tokenId: id,
             tokenAmount: amount
+        });
+    }
+
+    function _depositERC721(
+        address vault,
+        address token,
+        uint256 id
+    ) internal returns (IVaultInventoryReporter.Item memory) {
+        IERC721(token).safeTransferFrom(msg.sender, vault, id);
+
+        return IVaultInventoryReporter.Item({
+            itemType: IVaultInventoryReporter.ItemType.ERC_721,
+            tokenAddress: token,
+            tokenId: id,
+            tokenAmount: 0
         });
     }
 

--- a/contracts/vault/VaultDepositRouter.sol
+++ b/contracts/vault/VaultDepositRouter.sol
@@ -12,6 +12,8 @@ import "../interfaces/IVaultInventoryReporter.sol";
 import "../interfaces/IVaultFactory.sol";
 import "../external/interfaces/IPunks.sol";
 
+import "hardhat/console.sol";
+
 /**
  * @title VaultInventoryReporter
  * @author Non-Fungible Technologies, Inc.
@@ -324,6 +326,8 @@ contract VaultDepositRouter is IVaultDepositRouter {
         address token,
         uint256 id
     ) internal returns (IVaultInventoryReporter.Item memory) {
+        console.log("ID", msg.sender, token, address(this));
+        console.log("APPROVED", IERC721(token).getApproved(id));
         IERC721(token).safeTransferFrom(msg.sender, vault, id);
 
         return IVaultInventoryReporter.Item({

--- a/contracts/vault/VaultDepositRouter.sol
+++ b/contracts/vault/VaultDepositRouter.sol
@@ -124,8 +124,6 @@ contract VaultDepositRouter is IVaultDepositRouter {
         address token,
         uint256 id
     ) external override validate(vault, msg.sender) {
-        IERC721(token).safeTransferFrom(msg.sender, vault, id);
-
         IVaultInventoryReporter.Item[] memory items = new IVaultInventoryReporter.Item[](1);
 
         items[0] = _depositERC721(vault, token, id);
@@ -177,8 +175,6 @@ contract VaultDepositRouter is IVaultDepositRouter {
         uint256 id,
         uint256 amount
     ) external override validate(vault, msg.sender) {
-        IERC1155(token).safeTransferFrom(msg.sender, vault, id, amount, "");
-
         IVaultInventoryReporter.Item[] memory items = new IVaultInventoryReporter.Item[](1);
         items[0] = _depositERC1155(vault, token, id, amount);
 
@@ -326,8 +322,6 @@ contract VaultDepositRouter is IVaultDepositRouter {
         address token,
         uint256 id
     ) internal returns (IVaultInventoryReporter.Item memory) {
-        console.log("ID", msg.sender, token, address(this));
-        console.log("APPROVED", IERC721(token).getApproved(id));
         IERC721(token).safeTransferFrom(msg.sender, vault, id);
 
         return IVaultInventoryReporter.Item({

--- a/contracts/vault/VaultDepositRouter.sol
+++ b/contracts/vault/VaultDepositRouter.sol
@@ -12,8 +12,6 @@ import "../interfaces/IVaultInventoryReporter.sol";
 import "../interfaces/IVaultFactory.sol";
 import "../external/interfaces/IPunks.sol";
 
-import "hardhat/console.sol";
-
 /**
  * @title VaultInventoryReporter
  * @author Non-Fungible Technologies, Inc.
@@ -270,8 +268,8 @@ contract VaultDepositRouter is IVaultDepositRouter {
             items[i] = IVaultInventoryReporter.Item({
                 itemType: IVaultInventoryReporter.ItemType.PUNKS,
                 tokenAddress: token,
-                tokenId: 0,
-                tokenAmount: id
+                tokenId: id,
+                tokenAmount: 0
             });
         }
 

--- a/contracts/vault/VaultDepositRouter.sol
+++ b/contracts/vault/VaultDepositRouter.sol
@@ -341,7 +341,7 @@ contract VaultDepositRouter is IVaultDepositRouter, VaultOwnershipChecker {
      * @param caller                        The caller who wishes to deposit.
      */
     modifier validate(address vault, address caller) {
-        checkOwnership(factory, vault, caller);
+        _checkApproval(factory, vault, caller);
 
         _;
     }

--- a/contracts/vault/VaultDepositRouter.sol
+++ b/contracts/vault/VaultDepositRouter.sol
@@ -43,6 +43,14 @@ contract VaultDepositRouter is IVaultDepositRouter {
 
     // ====================================== DEPOSIT OPERATIONS ========================================
 
+    /**
+     * @notice Deposit an ERC20 token to the vault, registering its inventory on the reporter
+     *         simultaneously.
+     *
+     * @param vault                         The vault to deposit to.
+     * @param token                         The token to deposit.
+     * @param amount                        The amount of tokens to deposit.
+     */
     function depositERC20(
         address vault,
         address token,
@@ -64,6 +72,14 @@ contract VaultDepositRouter is IVaultDepositRouter {
         // No events because both token and reporter will emit
     }
 
+    /**
+     * @notice Deposit multiple ERC20 tokens to the vault, registering inventory on the reporter
+     *         simultaneously.
+     *
+     * @param vault                         The vault to deposit to.
+     * @param tokens                         The tokens to deposit.
+     * @param amounts                        The amount of tokens to deposit, for each token.
+     */
     function depositERC20Batch(
         address vault,
         address[] calldata tokens,
@@ -93,6 +109,14 @@ contract VaultDepositRouter is IVaultDepositRouter {
         // No events because both token and reporter will emit
     }
 
+    /**
+     * @notice Deposit an ERC721 token to the vault, registering its inventory on the reporter
+     *         simultaneously.
+     *
+     * @param vault                         The vault to deposit to.
+     * @param token                         The token to deposit.
+     * @param id                            The ID of the token to deposit.
+     */
     function depositERC721(
         address vault,
         address token,
@@ -114,6 +138,14 @@ contract VaultDepositRouter is IVaultDepositRouter {
         // No events because both token and reporter will emit
     }
 
+    /**
+     * @notice Deposit ERC721 tokens to the vault, registering inventory on the reporter
+     *         simultaneously.
+     *
+     * @param vault                         The vault to deposit to.
+     * @param tokens                        The token to deposit.
+     * @param ids                           The ID of the token to deposit, for each token.
+     */
     function depositERC721Batch(
         address vault,
         address[] calldata tokens,
@@ -143,6 +175,15 @@ contract VaultDepositRouter is IVaultDepositRouter {
         // No events because both token and reporter will emit
     }
 
+    /**
+     * @notice Deposit an ERC1155 token to the vault, registering its inventory on the reporter
+     *         simultaneously.
+     *
+     * @param vault                         The vault to deposit to.
+     * @param token                         The token to deposit.
+     * @param id                            The ID of the token to deposit.
+     * @param amount                        The amount of tokens to deposit.
+     */
     function depositERC1155(
         address vault,
         address token,
@@ -165,6 +206,15 @@ contract VaultDepositRouter is IVaultDepositRouter {
         // No events because both token and reporter will emit
     }
 
+    /**
+     * @notice Deposit ERC1155 tokens to the vault, registering its inventory on the reporter
+     *         simultaneously.
+     *
+     * @param vault                         The vault to deposit to.
+     * @param tokens                        The token to deposit.
+     * @param ids                           The ID of the tokens to deposit.
+     * @param amounts                       The amount of tokens to deposit, for each token.
+     */
     function depositERC1155Batch(
         address vault,
         address[] calldata tokens,
@@ -177,18 +227,7 @@ contract VaultDepositRouter is IVaultDepositRouter {
         IVaultInventoryReporter.Item[] memory items = new IVaultInventoryReporter.Item[](numItems);
 
         for (uint256 i = 0; i < numItems; i++) {
-            address token = tokens[i];
-            uint256 id = ids[i];
-            uint256 amount = amounts[i];
-
-            IERC1155(token).safeTransferFrom(msg.sender, vault, id, amount, "");
-
-            items[i] = IVaultInventoryReporter.Item({
-                itemType: IVaultInventoryReporter.ItemType.ERC_1155,
-                tokenAddress: token,
-                tokenId: id,
-                tokenAmount: amount
-            });
+            items[i] = _depositERC1155(vault, tokens[i], ids[i], amounts[i]);
         }
 
         reporter.add(vault, items);
@@ -196,6 +235,14 @@ contract VaultDepositRouter is IVaultDepositRouter {
         // No events because both token and reporter will emit
     }
 
+    /**
+     * @notice Deposit a CryptoPunk to the vault, registering its inventory on the reporter
+     *         simultaneously.
+     *
+     * @param vault                         The vault to deposit to.
+     * @param token                         The token to deposit.
+     * @param id                            The ID of the token to deposit.
+     */
     function depositPunk(
         address vault,
         address token,
@@ -218,6 +265,14 @@ contract VaultDepositRouter is IVaultDepositRouter {
         // No events because both token and reporter will emit
     }
 
+    /**
+     * @notice Deposit CryptoPunks to the vault, registering inventory on the reporter
+     *         simultaneously.
+     *
+     * @param vault                         The vault to deposit to.
+     * @param tokens                        The token to deposit.
+     * @param ids                           The ID of the tokens to deposit.
+     */
     function depositPunkBatch(
         address vault,
         address[] calldata tokens,
@@ -250,6 +305,13 @@ contract VaultDepositRouter is IVaultDepositRouter {
 
     // ============================================ HELPERS =============================================
 
+    /**
+     * @dev Validates that the caller is allowed to deposit to the specified vault (owner or approved),
+     *      and that the specified vault exists. Reverts on failed validation.
+     *
+     * @param vault                         The vault that will be deposited to.
+     * @param caller                        The caller who wishes to deposit.
+     */
     modifier validate(address vault, address caller) {
         if (vault == address(0)) revert VDR_ZeroAddress();
         if (!IVaultFactory(factory).isInstance(vault)) revert VDR_InvalidVault(vault);
@@ -264,6 +326,17 @@ contract VaultDepositRouter is IVaultDepositRouter {
         ) revert VDR_NotOwnerOrApproved(vault, caller);
 
         _;
+    }
+
+    function _depositERC1155(address vault, address token, uint256 id, uint256 amount) internal returns (IVaultInventoryReporter.Item memory) {
+        IERC1155(token).safeTransferFrom(msg.sender, vault, id, amount, "");
+
+        return IVaultInventoryReporter.Item({
+            itemType: IVaultInventoryReporter.ItemType.ERC_1155,
+            tokenAddress: token,
+            tokenId: id,
+            tokenAmount: amount
+        });
     }
 
 

--- a/contracts/vault/VaultInventoryReporter.sol
+++ b/contracts/vault/VaultInventoryReporter.sol
@@ -13,8 +13,7 @@ import "../external/interfaces/IPunks.sol";
 
 import "hardhat/console.sol";
 
-// TODO: Write router tests
-// TODO: Add repoter permissions
+// TODO: Add reporter permissions
 // TODO: Write reporter tests
 
 /**
@@ -28,6 +27,10 @@ import "hardhat/console.sol";
  * be used specifically to verify _whether_ certain items are in the
  * reported inventory, and not to get a sense of truth as to _all_
  * the items in a particular vault.
+ *
+ * Based on the method of storing inventory based on an itemsHash,
+ * the report is also idempotent - any matching itemsHash will simply
+ * update a status or amount, and will not increment any stored value.
  */
 contract VaultInventoryReporter is IVaultInventoryReporter {
     using EnumerableSet for EnumerableSet.Bytes32Set;

--- a/contracts/vault/VaultInventoryReporter.sol
+++ b/contracts/vault/VaultInventoryReporter.sol
@@ -29,12 +29,6 @@ import "../interfaces/IVaultInventoryReporter.sol";
 contract VaultInventoryReporter is IVaultInventoryReporter {
     using EnumerableSet for EnumerableSet.Bytes32Set;
 
-    error VIR_NoItems();
-    error VIR_TooManyItems(uint256 maxItems);
-    error VIR_InvalidRegistration(address vault, uint256 itemIndex);
-    error VIR_NotVerified(address vault, uint256 itemIndex);
-    error VIR_NotInInventory(address vault, bytes32 itemHash);
-
     // ============================================ STATE ==============================================
 
     // ============= Global Immutable State ==============
@@ -230,7 +224,7 @@ contract VaultInventoryReporter is IVaultInventoryReporter {
      */
     function itemAtIndex(address vault, uint256 index) external view override returns (Item memory) {
         bytes32 itemHash = inventoryKeysForVault[vault].at(index);
-            return inventoryForVault[vault][itemHash];
+        return inventoryForVault[vault][itemHash];
     }
 
     // =========================================== HELPERS =============================================

--- a/contracts/vault/VaultInventoryReporter.sol
+++ b/contracts/vault/VaultInventoryReporter.sol
@@ -9,9 +9,11 @@ import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
 
 import "../interfaces/IVaultInventoryReporter.sol";
+import "../external/interfaces/IPunks.sol";
 
 // TODO: Figure out punk verification
 // TODO: Write tests
+// TODO: Write deploy script
 
 /**
  * @title VaultInventoryReporter
@@ -68,19 +70,19 @@ contract VaultInventoryReporter is IVaultInventoryReporter {
             bytes32 itemHash = _hash(item);
 
             if (item.itemType == ItemType.ERC_721) {
-                if (IERC721(item.tokenAddress).ownerOf(item.tokenId) != vault){
+                if (IERC721(item.tokenAddress).ownerOf(item.tokenId) != vault) {
                     revert VIR_NotVerified(vault, i);
                 }
             } else if (item.itemType == ItemType.ERC_1155) {
-                if (IERC1155(item.tokenAddress).balanceOf(vault, item.tokenId) < item.tokenAmount){
+                if (IERC1155(item.tokenAddress).balanceOf(vault, item.tokenId) < item.tokenAmount) {
                     revert VIR_NotVerified(vault, i);
                 }
             } else if (item.itemType == ItemType.ERC_20) {
-                if (IERC20(item.tokenAddress).balanceOf(vault) < item.tokenAmount){
+                if (IERC20(item.tokenAddress).balanceOf(vault) < item.tokenAmount) {
                     revert VIR_NotVerified(vault, i);
                 }
             } else if (item.itemType == ItemType.PUNKS) {
-                if (IERC721(item.tokenAddress).ownerOf(item.tokenId) != vault){
+                if (IPunks(item.tokenAddress).punkIndexToAddress(item.tokenId) != vault) {
                     revert VIR_NotVerified(vault, i);
                 }
             }
@@ -242,17 +244,22 @@ contract VaultInventoryReporter is IVaultInventoryReporter {
      *
      * @return verified                     Whether the vault inventory is still accurate.
      */
+    // solhint-disable-next-line code-complexity
     function _verifyItem(address vault, Item memory item) internal view returns (bool) {
         if (item.itemType == ItemType.ERC_721) {
-            if (IERC721(item.tokenAddress).ownerOf(item.tokenId) != vault){
+            if (IERC721(item.tokenAddress).ownerOf(item.tokenId) != vault) {
                 return false;
             }
         } else if (item.itemType == ItemType.ERC_1155) {
-            if (IERC1155(item.tokenAddress).balanceOf(vault, item.tokenId) < item.tokenAmount){
+            if (IERC1155(item.tokenAddress).balanceOf(vault, item.tokenId) < item.tokenAmount) {
                 return false;
             }
         } else if (item.itemType == ItemType.ERC_20) {
-            if (IERC20(item.tokenAddress).balanceOf(vault) < item.tokenAmount){
+            if (IERC20(item.tokenAddress).balanceOf(vault) < item.tokenAmount) {
+                return false;
+            }
+        } else if (item.itemType == ItemType.PUNKS) {
+            if (IPunks(item.tokenAddress).punkIndexToAddress(item.tokenId) != vault) {
                 return false;
             }
         }

--- a/contracts/vault/VaultInventoryReporter.sol
+++ b/contracts/vault/VaultInventoryReporter.sol
@@ -16,9 +16,6 @@ import "./OwnableERC721.sol";
 import "../interfaces/IVaultInventoryReporter.sol";
 import "../external/interfaces/IPunks.sol";
 
-// TODO: Write reporter tests
-import "hardhat/console.sol";
-
 /**
  * @title VaultInventoryReporter
  * @author Non-Fungible Technologies, Inc.

--- a/contracts/vault/VaultInventoryReporter.sol
+++ b/contracts/vault/VaultInventoryReporter.sol
@@ -135,6 +135,7 @@ contract VaultInventoryReporter is IVaultInventoryReporter, VaultOwnershipChecke
     function remove(address vault, Item[] calldata items) public override validate(msg.sender, vault) {
         uint256 numItems = items.length;
 
+        if (numItems == 0) revert VIR_NoItems();
         if (numItems > MAX_ITEMS_PER_REGISTRATION) revert VIR_TooManyItems(MAX_ITEMS_PER_REGISTRATION);
 
         for (uint256 i = 0; i < numItems; i++) {

--- a/contracts/vault/VaultInventoryReporter.sol
+++ b/contracts/vault/VaultInventoryReporter.sol
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity ^0.8.11;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
+
+import "../interfaces/IVaultInventoryReporter.sol";
+
+// TODO: Write reporter contract
+// TODO: Write vault deposit router
+// TODO: Write tests
+
+/**
+ * @title VaultInventoryReporter
+ * @author Non-Fungible Technologies, Inc.
+ *
+ * The VaultInventoryReporter contract is a global tracker of reported
+ * inventory in all Arcade Asset Vaults. This reporting should _always_
+ * be accurate, but will _not_ be comprehensive - that is, many vaults
+ * will end up having unreported inventory. This contract should
+ * be used specifically to verify _whether_ certain items are in the
+ * reported inventory, and not to get a sense of truth as to _all_
+ * the items in a particular vault.
+ */
+contract VaultInventoryReporter is IVaultInventoryReporter {
+    using EnumerableSet for EnumerableSet.Bytes32Set;
+
+    error VIR_NoItems();
+    error VIR_TooManyItems(uint256 maxItems);
+    error VIR_InvalidRegistration(address vault, uint256 itemIndex);
+    error VIR_NotVerified(address vault, uint256 itemIndex);
+    error VIR_NotInInventory(address vault, bytes32 itemHash);
+
+    // ============================================ STATE ==============================================
+
+    // ============= Global Immutable State ==============
+
+    /// @dev To prevent gas consumption issues, registering more than 50 items
+    ///      in a single transaction will revert.
+    uint256 public constant MAX_ITEMS_PER_REGISTRATION = 50;
+
+    // ============= Inventory State ==============
+
+    /// @notice vault address -> itemHash -> Item metadata
+    mapping(address => mapping(bytes32 => Item)) public inventoryForVault;
+    /// @notice vault address -> itemHash[] (for enumeration)
+    mapping(address => EnumerableSet.Bytes32Set) private inventoryKeysForVault;
+
+    // ===================================== INVENTORY OPERATIONS ======================================
+
+    /**
+     * @notice Add items to the vault's registered inventory. If specified items
+     *         are not owned by the vault, add will revert.
+     *
+     * @param vault                         The address of the vault.
+     * @param items                         The list of items to add.
+     */
+    // solhint-disable-next-line code-complexity
+    function add(address vault, Item[] calldata items) external override {
+        // For each item, verify the vault actually owns it, or revert
+        uint256 numItems = items.length;
+
+        if (numItems == 0) revert VIR_NoItems();
+        if (numItems > MAX_ITEMS_PER_REGISTRATION) revert VIR_TooManyItems(MAX_ITEMS_PER_REGISTRATION);
+
+        for (uint256 i = 0; i < numItems; i++) {
+            Item calldata item = items[i];
+
+            if (item.tokenAddress == address(0)) revert VIR_InvalidRegistration(vault, i);
+
+            bytes32 itemHash = _hash(item);
+
+            if (item.itemType == ItemType.ERC_721) {
+                if (IERC721(item.tokenAddress).ownerOf(item.tokenId) != vault){
+                    revert VIR_NotVerified(vault, i);
+                }
+            } else if (item.itemType == ItemType.ERC_1155) {
+                if (IERC1155(item.tokenAddress).balanceOf(vault, item.tokenId) < item.tokenAmount){
+                    revert VIR_NotVerified(vault, i);
+                }
+            } else if (item.itemType == ItemType.ERC_20) {
+                if (IERC20(item.tokenAddress).balanceOf(vault) < item.tokenAmount){
+                    revert VIR_NotVerified(vault, i);
+                }
+            }
+
+            // If all checks pass, add item to inventory, replacing anything with the same item hash
+            // Does not encode itemType, meaning updates can be made if wrong item type was submitted
+            inventoryForVault[vault][itemHash] = item;
+            inventoryKeysForVault[vault].add(itemHash);
+        }
+    }
+
+    /**
+     * @notice Remove items from the vault's registered inventory. If specified items
+     *         are not registered as inventory, the function will not revert.
+     *
+     * @param vault                         The address of the vault.
+     * @param items                         The list of items to remove.
+     */
+    function remove(address vault, Item[] calldata items) external override {
+        uint256 numItems = items.length;
+
+        if (numItems > MAX_ITEMS_PER_REGISTRATION) revert VIR_TooManyItems(MAX_ITEMS_PER_REGISTRATION);
+
+        for (uint256 i = 0; i < numItems; i++) {
+            bytes32 itemHash = _hash(items[i]);
+
+            delete inventoryForVault[vault][itemHash];
+            inventoryKeysForVault[vault].remove(itemHash);
+        }
+    }
+
+    /**
+     * @notice Remove all items from the vault's registered inventory.
+     *
+     * @param vault                         The address of the vault.
+     */
+    function clear(address vault) external override {
+        uint256 numItems = inventoryKeysForVault[vault].length();
+
+        if (numItems > MAX_ITEMS_PER_REGISTRATION) revert VIR_TooManyItems(MAX_ITEMS_PER_REGISTRATION);
+
+        for (uint256 i = 0; i < numItems; i++) {
+            bytes32 itemHash = inventoryKeysForVault[vault].at(i);
+
+            delete inventoryForVault[vault][itemHash];
+            inventoryKeysForVault[vault].remove(itemHash);
+        }
+    }
+
+    // ========================================= VERIFICATION ==========================================
+
+    /**
+     * @notice Check each item in a vault's inventory against on-chain state,
+     *         returning true if all items in inventory are still held by the vault,
+     *         and false if otherwise.
+     *
+     * @param vault                         The address of the vault.
+     *
+     * @return verified                     Whether the vault inventory is still accurate.
+     */
+    function verify(address vault) external view override returns (bool) {
+        uint256 numItems = inventoryKeysForVault[vault].length();
+
+        for (uint256 i = 0; i < numItems; i++) {
+            bytes32 itemHash = inventoryKeysForVault[vault].at(i);
+
+            if (!_verifyItem(vault, inventoryForVault[vault][itemHash])) return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @notice Check a specific item in the vault's inventory against on-chain state,
+     *         returning true if all items in inventory are still held by the vault,
+     *         and false if otherwise. Reverts if item not in inventory.
+     *
+     * @param vault                         The address of the vault.
+     * @param item                          The item to verify.
+     *
+     * @return verified                     Whether the vault inventory is still accurate.
+     */
+    function verifyItem(address vault, Item memory item) external view override returns (bool) {
+        bytes32 itemHash = _hash(item);
+
+        if (!inventoryKeysForVault[vault].contains(itemHash)) {
+            revert VIR_NotInInventory(vault, itemHash);
+        }
+
+        return _verifyItem(vault, item);
+    }
+
+    // ========================================= ENUMERATION ===========================================
+
+    /**
+     * @notice Return a list of items in the vault. Does not check for staleness.
+     *
+     * @param vault                         The address of the vault.
+     *
+     * @return items                        An array of items in the vault.
+     */
+    function enumerate(address vault) external view override returns (Item[] memory items) {
+        uint256 numItems = inventoryKeysForVault[vault].length();
+
+        for (uint256 i = 0; i < numItems; i++) {
+            bytes32 itemHash = inventoryKeysForVault[vault].at(i);
+
+            items[i] = inventoryForVault[vault][itemHash];
+        }
+    }
+
+    /**
+     * @notice Return a list of lookup keys for items in the vault, which is each item's
+     *         itemHash value. Does not check for staleness.
+     *
+     * @param vault                         The address of the vault.
+     *
+     * @return keys                         An array of lookup keys for all vault items.
+     */
+    function keys(address vault) external view override returns (bytes32[] memory) {
+        return inventoryKeysForVault[vault].values();
+    }
+
+    /**
+     * @notice Return the lookup key at the specified index. Does not check for staleness.
+     *
+     * @param vault                         The address of the vault.
+     * @param index                         The index of the key to look up.
+     *
+     * @return key                          The key at the specified index.
+     */
+    function keyAtIndex(address vault, uint256 index) external view override returns (bytes32) {
+        return inventoryKeysForVault[vault].at(index);
+    }
+
+    /**
+     * @notice Return the item stored by the lookup key at the specified index.
+     *         Does not check for staleness.
+     *
+     * @param vault                         The address of the vault.
+     * @param index                         The index of the key to look up.
+     *
+     * @return item                         The item at the specified index.
+     */
+    function itemAtIndex(address vault, uint256 index) external view override returns (Item memory) {
+        bytes32 itemHash = inventoryKeysForVault[vault].at(index);
+            return inventoryForVault[vault][itemHash];
+    }
+
+    // =========================================== HELPERS =============================================
+
+
+    /**
+     * @dev Read the Item struct and check owner/balance function according
+     *      to item type.
+     *
+     * @param vault                         The address of the vault.
+     * @param item                          The item to verify.
+     *
+     * @return verified                     Whether the vault inventory is still accurate.
+     */
+    function _verifyItem(address vault, Item memory item) internal view returns (bool) {
+        if (item.itemType == ItemType.ERC_721) {
+            if (IERC721(item.tokenAddress).ownerOf(item.tokenId) != vault){
+                return false;
+            }
+        } else if (item.itemType == ItemType.ERC_1155) {
+            if (IERC1155(item.tokenAddress).balanceOf(vault, item.tokenId) < item.tokenAmount){
+                return false;
+            }
+        } else if (item.itemType == ItemType.ERC_20) {
+            if (IERC20(item.tokenAddress).balanceOf(vault) < item.tokenAmount){
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @dev Hash the fields of the Item struct.
+     *
+     * @param item                          The item to hash.
+     *
+     * @return hash                         The digest of the hash.
+     */
+    function _hash(Item memory item) internal pure returns (bytes32) {
+        // TODO: Decide on image for itemsHash
+        return keccak256(abi.encodePacked(item.tokenAddress, item.tokenId, item.tokenAmount));
+    }
+}

--- a/contracts/vault/VaultInventoryReporter.sol
+++ b/contracts/vault/VaultInventoryReporter.sol
@@ -10,7 +10,6 @@ import "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
 
 import "../interfaces/IVaultInventoryReporter.sol";
 
-// TODO: Write reporter contract
 // TODO: Write vault deposit router
 // TODO: Write tests
 
@@ -78,6 +77,10 @@ contract VaultInventoryReporter is IVaultInventoryReporter {
                 }
             } else if (item.itemType == ItemType.ERC_20) {
                 if (IERC20(item.tokenAddress).balanceOf(vault) < item.tokenAmount){
+                    revert VIR_NotVerified(vault, i);
+                }
+            } else if (item.itemType == ItemType.PUNKS) {
+                if (IERC721(item.tokenAddress).ownerOf(item.tokenId) != vault){
                     revert VIR_NotVerified(vault, i);
                 }
             }

--- a/contracts/vault/VaultInventoryReporter.sol
+++ b/contracts/vault/VaultInventoryReporter.sol
@@ -10,7 +10,7 @@ import "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
 
 import "../interfaces/IVaultInventoryReporter.sol";
 
-// TODO: Write vault deposit router
+// TODO: Figure out punk verification
 // TODO: Write tests
 
 /**
@@ -268,7 +268,6 @@ contract VaultInventoryReporter is IVaultInventoryReporter {
      * @return hash                         The digest of the hash.
      */
     function _hash(Item memory item) internal pure returns (bytes32) {
-        // TODO: Decide on image for itemsHash
         return keccak256(abi.encodePacked(item.tokenAddress, item.tokenId, item.tokenAmount));
     }
 }

--- a/contracts/vault/VaultInventoryReporter.sol
+++ b/contracts/vault/VaultInventoryReporter.sol
@@ -13,9 +13,8 @@ import "../external/interfaces/IPunks.sol";
 
 import "hardhat/console.sol";
 
-// TODO: Add events
 // TODO: Write tests
-// TODO: Write deploy script
+// TODO: Add permissions
 
 /**
  * @title VaultInventoryReporter
@@ -93,6 +92,8 @@ contract VaultInventoryReporter is IVaultInventoryReporter {
             // Does not encode itemType, meaning updates can be made if wrong item type was submitted
             inventoryForVault[vault][itemHash] = item;
             inventoryKeysForVault[vault].add(itemHash);
+
+            emit Add(vault, msg.sender, itemHash);
         }
     }
 
@@ -113,6 +114,8 @@ contract VaultInventoryReporter is IVaultInventoryReporter {
 
             delete inventoryForVault[vault][itemHash];
             inventoryKeysForVault[vault].remove(itemHash);
+
+            emit Remove(vault, msg.sender, itemHash);
         }
     }
 
@@ -132,6 +135,8 @@ contract VaultInventoryReporter is IVaultInventoryReporter {
             delete inventoryForVault[vault][itemHash];
             inventoryKeysForVault[vault].remove(itemHash);
         }
+
+        emit Clear(vault, msg.sender);
     }
 
     // ========================================= VERIFICATION ==========================================

--- a/contracts/vault/VaultInventoryReporter.sol
+++ b/contracts/vault/VaultInventoryReporter.sol
@@ -5,18 +5,16 @@ pragma solidity ^0.8.11;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/utils/Counters.sol";
 
 import "./VaultOwnershipChecker.sol";
 import "./OwnableERC721.sol";
 import "../interfaces/IVaultInventoryReporter.sol";
 import "../external/interfaces/IPunks.sol";
-
-import "hardhat/console.sol";
-
-// TODO: Add reporter permissions
-// TODO: Add permits
 
 // TODO: Write reporter tests
 
@@ -36,8 +34,9 @@ import "hardhat/console.sol";
  * the report is also idempotent - any matching itemsHash will simply
  * update a status or amount, and will not increment any stored value.
  */
-contract VaultInventoryReporter is IVaultInventoryReporter, VaultOwnershipChecker {
+contract VaultInventoryReporter is IVaultInventoryReporter, VaultOwnershipChecker, EIP712 {
     using EnumerableSet for EnumerableSet.Bytes32Set;
+    using Counters for Counters.Counter;
 
     // ============================================ STATE ==============================================
 
@@ -57,6 +56,24 @@ contract VaultInventoryReporter is IVaultInventoryReporter, VaultOwnershipChecke
     ///         vault -> approved address
     mapping(address => address) public approved;
 
+    // ============= Permit Functionality ==============
+
+    // solhint-disable-next-line var-name-mixedcase
+    bytes32 private immutable _PERMIT_TYPEHASH =
+        keccak256("Permit(address owner,address target,address vault,uint256 nonce,uint256 deadline)");
+
+    /// @dev Nonce for permit signatures.
+    mapping(address => Counters.Counter) private _nonces;
+
+    // ========================================== CONSTRUCTOR ===========================================
+
+    /**
+     * @dev Initializes the {EIP712} domain separator using the `name` parameter, and setting `version` to `"1"`.
+     *
+     * @param name                  The name of the signing domain.
+     */
+    constructor(string memory name) EIP712(name, "1") {}
+
     // ===================================== INVENTORY OPERATIONS ======================================
 
     /**
@@ -67,7 +84,7 @@ contract VaultInventoryReporter is IVaultInventoryReporter, VaultOwnershipChecke
      * @param items                         The list of items to add.
      */
     // solhint-disable-next-line code-complexity
-    function add(address vault, Item[] calldata items) external override validate(msg.sender, vault) {
+    function add(address vault, Item[] calldata items) public override validate(msg.sender, vault) {
         // For each item, verify the vault actually owns it, or revert
         uint256 numItems = items.length;
 
@@ -115,7 +132,7 @@ contract VaultInventoryReporter is IVaultInventoryReporter, VaultOwnershipChecke
      * @param vault                         The address of the vault.
      * @param items                         The list of items to remove.
      */
-    function remove(address vault, Item[] calldata items) external override validate(msg.sender, vault) {
+    function remove(address vault, Item[] calldata items) public override validate(msg.sender, vault) {
         uint256 numItems = items.length;
 
         if (numItems > MAX_ITEMS_PER_REGISTRATION) revert VIR_TooManyItems(MAX_ITEMS_PER_REGISTRATION);
@@ -135,7 +152,7 @@ contract VaultInventoryReporter is IVaultInventoryReporter, VaultOwnershipChecke
      *
      * @param vault                         The address of the vault.
      */
-    function clear(address vault) external override validate(msg.sender, vault) {
+    function clear(address vault) public override validate(msg.sender, vault) {
         uint256 numItems = inventoryKeysForVault[vault].length();
 
         if (numItems > MAX_ITEMS_PER_REGISTRATION) revert VIR_TooManyItems(MAX_ITEMS_PER_REGISTRATION);
@@ -148,6 +165,111 @@ contract VaultInventoryReporter is IVaultInventoryReporter, VaultOwnershipChecke
         }
 
         emit Clear(vault, msg.sender);
+    }
+
+    /**
+     * @notice Add items to the vault's registered inventory, using permit. If specified items
+     *         are not owned by the vault, add will revert.
+     *
+     * @param vault                         The address of the vault.
+     * @param items                         The list of items to add.
+     * @param deadline                      The maximum timestamp the signature is valid for.
+     * @param v                             Component of the signature.
+     * @param r                             Component of the signature.
+     * @param s                             Component of the signature.
+     */
+    function addWithPermit(
+        address vault,
+        Item[] calldata items,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external override {
+        uint256 tokenId = uint256(uint160(vault));
+        address factory = OwnableERC721(vault).ownershipToken();
+        address owner = IERC721(factory).ownerOf(tokenId);
+
+        permit(
+            owner,
+            msg.sender,
+            vault,
+            deadline,
+            v,
+            r,
+            s
+        );
+
+        add(vault, items);
+    }
+
+    /**
+     * @notice Remove items from the vault's registered inventory, using permit. If specified items
+     *         are not registered as inventory, the function will not revert.
+     *
+     * @param vault                         The address of the vault.
+     * @param items                         The list of items to remove.
+     * @param deadline                      The maximum timestamp the signature is valid for.
+     * @param v                             Component of the signature.
+     * @param r                             Component of the signature.
+     * @param s                             Component of the signature.
+     */
+    function removeWithPermit(
+        address vault,
+        Item[] calldata items,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external override {
+        uint256 tokenId = uint256(uint160(vault));
+        address factory = OwnableERC721(vault).ownershipToken();
+        address owner = IERC721(factory).ownerOf(tokenId);
+
+        permit(
+            owner,
+            msg.sender,
+            vault,
+            deadline,
+            v,
+            r,
+            s
+        );
+
+        remove(vault, items);
+    }
+
+    /**
+     * @notice Remove all items from the vault's registered inventory, using permit.
+     *
+     * @param vault                         The address of the vault.
+     * @param deadline                      The maximum timestamp the signature is valid for.
+     * @param v                             Component of the signature.
+     * @param r                             Component of the signature.
+     * @param s                             Component of the signature.
+     */
+    function clearWithPermit(
+        address vault,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external override {
+        uint256 tokenId = uint256(uint160(vault));
+        address factory = OwnableERC721(vault).ownershipToken();
+        address owner = IERC721(factory).ownerOf(tokenId);
+
+        permit(
+            owner,
+            msg.sender,
+            vault,
+            deadline,
+            v,
+            r,
+            s
+        );
+
+        clear(vault);
     }
 
     // ========================================= VERIFICATION ==========================================
@@ -288,7 +410,7 @@ contract VaultInventoryReporter is IVaultInventoryReporter, VaultOwnershipChecke
      */
     function setApproval(address vault, address target) external override {
         address factory = OwnableERC721(vault).ownershipToken();
-        checkOwnership(factory, vault, msg.sender);
+        _checkApproval(factory, vault, msg.sender);
 
         // Set approval, overwriting any previous
         // If zero, results in no approvals
@@ -298,7 +420,12 @@ contract VaultInventoryReporter is IVaultInventoryReporter, VaultOwnershipChecke
     }
 
     /**
-     * @notice Reports.
+     * @notice Reports whether the target is an owner of the vault, or approved
+     *         to report inventory on behalf of the vault. Note that this approval
+     *         does NOT equate to a token approval.
+     *
+     * @param vault                         The vault to check approval for.
+     * @param target                        The address to check approval for.
      */
     function isOwnerOrApproved(address vault, address target) public view override returns (bool) {
         address factory = OwnableERC721(vault).ownershipToken();
@@ -308,8 +435,61 @@ contract VaultInventoryReporter is IVaultInventoryReporter, VaultOwnershipChecke
         return owner == target || approved[vault] == target;
     }
 
+    /**
+     * @notice Allows the target to update inventory for a particular vault,
+     *         given owner's signed approval. Note that, unlike token approvals,
+     *         an inventory reporting approval cannot be "spent" - the signature
+     *         will work for an unlimited number of applications until the deadline.
+     *         Therefore unlike a token permit which is often spent before its
+     *         deadline, an inventory permit should be considered unqualified approval
+     *         until the deadline.
+     *
+     * @param owner                 The owner of the vault being permitted.
+     * @param target                The address allowed to report inventory for the token.
+     * @param vault                 The given vault for the permission.
+     * @param deadline              The maximum timestamp the signature is valid for.
+     * @param v                     Component of the signature.
+     * @param r                     Component of the signature.
+     * @param s                     Component of the signature.
+     */
+    function permit(
+        address owner,
+        address target,
+        address vault,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public override {
+        if (block.timestamp > deadline) revert VIR_PermitDeadlineExpired(deadline);
+        address factory = OwnableERC721(vault).ownershipToken();
+        _checkOwnership(factory, vault, owner);
+
+        bytes32 structHash = keccak256(
+            abi.encode(_PERMIT_TYPEHASH, owner, target, vault, _useNonce(owner), deadline)
+        );
+
+        bytes32 hash = _hashTypedDataV4(structHash);
+
+        address signer = ECDSA.recover(hash, v, r, s);
+        if (signer != owner) revert VIR_InvalidPermitSignature(signer);
+
+        // Set approval, overwriting any previous
+        // If zero, results in no approvals
+        approved[vault] = target;
+    }
+
     // =========================================== HELPERS =============================================
 
+    /**
+     * @notice Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.
+     *
+     * @return separator             The bytes for the domain separator.
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function DOMAIN_SEPARATOR() external view override returns (bytes32) {
+        return _domainSeparatorV4();
+    }
 
     /**
      * @dev Read the Item struct and check owner/balance function according
@@ -354,9 +534,30 @@ contract VaultInventoryReporter is IVaultInventoryReporter, VaultOwnershipChecke
         return keccak256(abi.encodePacked(item.tokenAddress, item.tokenId, item.tokenAmount));
     }
 
+    /**
+     * @dev Consumes the nonce - returns the current value and increments.
+     *
+     * @param owner                 The address of the user to consume a nonce for.
+     *
+     * @return current              The current nonce, before incrementation.
+     */
+    function _useNonce(address owner) internal virtual returns (uint256 current) {
+        Counters.Counter storage nonce = _nonces[owner];
+        current = nonce.current();
+        nonce.increment();
+    }
+
+    /**
+     * @dev Checks that the caller is owner or approved for the vault
+     *      before any update action.
+     *
+     * @param caller                        The msg.sender.
+     * @param vault                         The vault being called on.
+     */
     modifier validate(address caller, address vault) {
         // If caller is not owner or approved for vault, then revert
         if (!isOwnerOrApproved(vault, caller)) revert VIR_NotApproved(vault, caller);
 
+        _;
     }
 }

--- a/contracts/vault/VaultInventoryReporter.sol
+++ b/contracts/vault/VaultInventoryReporter.sol
@@ -13,8 +13,9 @@ import "../external/interfaces/IPunks.sol";
 
 import "hardhat/console.sol";
 
-// TODO: Write tests
-// TODO: Add permissions
+// TODO: Write router tests
+// TODO: Add repoter permissions
+// TODO: Write reporter tests
 
 /**
  * @title VaultInventoryReporter

--- a/contracts/vault/VaultOwnershipChecker.sol
+++ b/contracts/vault/VaultOwnershipChecker.sol
@@ -8,13 +8,20 @@ import "../interfaces/IVaultDepositRouter.sol";
 import "../interfaces/IVaultInventoryReporter.sol";
 import "../interfaces/IVaultFactory.sol";
 
+/**
+ * @title VaultOwnershipChecker
+ * @author Non-Fungible Technologies, Inc.
+ *
+ * This abstract contract contains utility functions for checking AssetVault
+ * ownership or approval, which is needed for many contracts which work with vaults.
+ */
 abstract contract VaultOwnershipChecker {
 
     // ============= Errors ==============
 
     error VOC_ZeroAddress();
     error VOC_InvalidVault(address vault);
-    error VOC_NotOwnerOrApproved(address vault, address caller);
+    error VOC_NotOwnerOrApproved(address vault, address owner, address caller);
 
     // ================ Ownership Check ================
 
@@ -37,7 +44,7 @@ abstract contract VaultOwnershipChecker {
             caller != owner
             && IERC721(factory).getApproved(tokenId) != caller
             && !IERC721(factory).isApprovedForAll(owner, caller)
-        ) revert VOC_NotOwnerOrApproved(vault, caller);
+        ) revert VOC_NotOwnerOrApproved(vault, owner, caller);
     }
 
     /**
@@ -55,6 +62,6 @@ abstract contract VaultOwnershipChecker {
         uint256 tokenId = uint256(uint160(vault));
         address owner = IERC721(factory).ownerOf(tokenId);
 
-        if (caller != owner) revert VOC_NotOwnerOrApproved(vault, caller);
+        if (caller != owner) revert VOC_NotOwnerOrApproved(vault, owner, caller);
     }
 }

--- a/contracts/vault/VaultOwnershipChecker.sol
+++ b/contracts/vault/VaultOwnershipChecker.sol
@@ -30,7 +30,7 @@ abstract contract VaultOwnershipChecker {
      * @param vault                         The vault that will be deposited to.
      * @param caller                        The caller who wishes to deposit.
      */
-    function checkOwnership(address factory, address vault, address caller) public view returns (bool) {
+    function _checkApproval(address factory, address vault, address caller) internal view {
         if (vault == address(0)) revert VOC_ZeroAddress();
         if (!IVaultFactory(factory).isInstance(vault)) revert VOC_InvalidVault(vault);
 
@@ -42,5 +42,23 @@ abstract contract VaultOwnershipChecker {
             && IERC721(factory).getApproved(tokenId) != caller
             && !IERC721(factory).isApprovedForAll(owner, caller)
         ) revert VOC_NotOwnerOrApproved(vault, caller);
+    }
+
+    /**
+     * @dev Validates that the caller is directly the owner of the vault,
+     *      and that the specified vault exists. Reverts on failed validation.
+     *
+     * @param factory                       The vault ownership token for the specifide vault.
+     * @param vault                         The vault that will be deposited to.
+     * @param caller                        The caller who wishes to deposit.
+     */
+    function _checkOwnership(address factory, address vault, address caller) public view {
+        if (vault == address(0)) revert VOC_ZeroAddress();
+        if (!IVaultFactory(factory).isInstance(vault)) revert VOC_InvalidVault(vault);
+
+        uint256 tokenId = uint256(uint160(vault));
+        address owner = IERC721(factory).ownerOf(tokenId);
+
+        if (caller != owner) revert VOC_NotOwnerOrApproved(vault, caller);
     }
 }

--- a/contracts/vault/VaultOwnershipChecker.sol
+++ b/contracts/vault/VaultOwnershipChecker.sol
@@ -22,7 +22,7 @@ abstract contract VaultOwnershipChecker {
      * @dev Validates that the caller is allowed to deposit to the specified vault (owner or approved),
      *      and that the specified vault exists. Reverts on failed validation.
      *
-     * @param factory                       The vault ownership token for the specifide vault.
+     * @param factory                       The vault ownership token for the specified vault.
      * @param vault                         The vault that will be deposited to.
      * @param caller                        The caller who wishes to deposit.
      */
@@ -44,7 +44,7 @@ abstract contract VaultOwnershipChecker {
      * @dev Validates that the caller is directly the owner of the vault,
      *      and that the specified vault exists. Reverts on failed validation.
      *
-     * @param factory                       The vault ownership token for the specifide vault.
+     * @param factory                       The vault ownership token for the specified vault.
      * @param vault                         The vault that will be deposited to.
      * @param caller                        The caller who wishes to deposit.
      */

--- a/contracts/vault/VaultOwnershipChecker.sol
+++ b/contracts/vault/VaultOwnershipChecker.sol
@@ -3,14 +3,10 @@
 pragma solidity ^0.8.11;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
-import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import "../interfaces/IVaultDepositRouter.sol";
 import "../interfaces/IVaultInventoryReporter.sol";
 import "../interfaces/IVaultFactory.sol";
-import "../external/interfaces/IPunks.sol";
 
 abstract contract VaultOwnershipChecker {
 

--- a/contracts/vault/VaultOwnershipChecker.sol
+++ b/contracts/vault/VaultOwnershipChecker.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.11;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import "../interfaces/IVaultDepositRouter.sol";
+import "../interfaces/IVaultInventoryReporter.sol";
+import "../interfaces/IVaultFactory.sol";
+import "../external/interfaces/IPunks.sol";
+
+abstract contract VaultOwnershipChecker {
+
+    // ============= Errors ==============
+
+    error VOC_ZeroAddress();
+    error VOC_InvalidVault(address vault);
+    error VOC_NotOwnerOrApproved(address vault, address caller);
+
+    // ================ Ownership Check ================
+
+    /**
+     * @dev Validates that the caller is allowed to deposit to the specified vault (owner or approved),
+     *      and that the specified vault exists. Reverts on failed validation.
+     *
+     * @param factory                       The vault ownership token for the specifide vault.
+     * @param vault                         The vault that will be deposited to.
+     * @param caller                        The caller who wishes to deposit.
+     */
+    function checkOwnership(address factory, address vault, address caller) public view returns (bool) {
+        if (vault == address(0)) revert VOC_ZeroAddress();
+        if (!IVaultFactory(factory).isInstance(vault)) revert VOC_InvalidVault(vault);
+
+        uint256 tokenId = uint256(uint160(vault));
+        address owner = IERC721(factory).ownerOf(tokenId);
+
+        if (
+            caller != owner
+            && IERC721(factory).getApproved(tokenId) != caller
+            && !IERC721(factory).isApprovedForAll(owner, caller)
+        ) revert VOC_NotOwnerOrApproved(vault, caller);
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -148,7 +148,7 @@ export const config: HardhatUserConfig = {
                     optimizer: {
                         enabled: optimizerEnabled,
                         runs: 200,
-                    }
+                    },
                 },
             },
             {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -148,7 +148,7 @@ export const config: HardhatUserConfig = {
                     optimizer: {
                         enabled: optimizerEnabled,
                         runs: 200,
-                    },
+                    }
                 },
             },
             {

--- a/scripts/deploy/deploy-inventory-reporter.ts
+++ b/scripts/deploy/deploy-inventory-reporter.ts
@@ -1,0 +1,50 @@
+import hre, { ethers } from "hardhat";
+import { SECTION_SEPARATOR, SUBSECTION_SEPARATOR } from "../utils/bootstrap-tools";
+
+import {
+    VaultDepositRouter,
+    VaultInventoryReporter
+} from "../../typechain";
+
+export interface DeployedResources {
+    reporter: VaultInventoryReporter;
+    router: VaultDepositRouter;
+}
+
+export async function main(): Promise<DeployedResources> {
+    // Hardhat always runs the compile task when running scripts through it.
+    // If this runs in a standalone fashion you may want to call compile manually
+    // to make sure everything is compiled
+    // await run("compile");
+
+    console.log(SECTION_SEPARATOR);
+
+    // const VAULT_FACTORY = "0x6e9B4c2f6Bd57b7b924d29b5dcfCa1273Ecc94A2"; // mainnet
+    const VAULT_FACTORY = "0x0028BADf5d154DAE44F874AC58FFCd3fA56D9586" // goerli
+
+    const reporterFactory = await ethers.getContractFactory("VaultInventoryReporter");
+    // const reporter = <VaultInventoryReporter>await reporterFactory.deploy();
+    const reporter = <VaultInventoryReporter>await reporterFactory.attach("0x606E4a441290314aEaF494194467Fd2Bb844064A");
+    await reporter.deployed();
+
+    // console.log("Inventory Reporter deployed to:", reporter.address);
+
+    const routerFactory = await ethers.getContractFactory("VaultDepositRouter");
+    const router = <VaultDepositRouter>await routerFactory.deploy(VAULT_FACTORY, reporter.address);
+    await router.deployed();
+
+    console.log("Vault Deposit Router deployed to:", router.address);
+
+    return { reporter, router };
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+if (require.main === module) {
+    main()
+        .then(() => process.exit(0))
+        .catch((error: Error) => {
+            console.error(error);
+            process.exit(1);
+        });
+}

--- a/scripts/deploy/deploy-inventory-reporter.ts
+++ b/scripts/deploy/deploy-inventory-reporter.ts
@@ -35,6 +35,10 @@ export async function main(): Promise<DeployedResources> {
 
     console.log("Vault Deposit Router deployed to:", router.address);
 
+    await reporter.setGlobalApproval(router.address, true);
+
+    console.log("Global approval set for router.");
+
     return { reporter, router };
 }
 

--- a/scripts/deploy/deploy-inventory-reporter.ts
+++ b/scripts/deploy/deploy-inventory-reporter.ts
@@ -23,11 +23,11 @@ export async function main(): Promise<DeployedResources> {
     const VAULT_FACTORY = "0x0028BADf5d154DAE44F874AC58FFCd3fA56D9586" // goerli
 
     const reporterFactory = await ethers.getContractFactory("VaultInventoryReporter");
-    // const reporter = <VaultInventoryReporter>await reporterFactory.deploy();
-    const reporter = <VaultInventoryReporter>await reporterFactory.attach("0x606E4a441290314aEaF494194467Fd2Bb844064A");
+    const reporter = <VaultInventoryReporter>await reporterFactory.deploy("Arcade.xyz Inventory Reporter v1.0");
+    // const reporter = <VaultInventoryReporter>await reporterFactory.attach("0x606E4a441290314aEaF494194467Fd2Bb844064A");
     await reporter.deployed();
 
-    // console.log("Inventory Reporter deployed to:", reporter.address);
+    console.log("Inventory Reporter deployed to:", reporter.address);
 
     const routerFactory = await ethers.getContractFactory("VaultDepositRouter");
     const router = <VaultDepositRouter>await routerFactory.deploy(VAULT_FACTORY, reporter.address);

--- a/test/VaultDepositRouter.ts
+++ b/test/VaultDepositRouter.ts
@@ -128,7 +128,7 @@ describe("VaultDepositRouter", () => {
         });
     });
 
-    describe.only("Deposits", () => {
+    describe("Deposits", () => {
         it("should not accept a deposit for the zero address", async () => {
             const { mockERC20, user, router } = await loadFixture(fixture);
             const amount = hre.ethers.utils.parseUnits("50", 18);
@@ -292,6 +292,15 @@ describe("VaultDepositRouter", () => {
             // approve router to send ERC20 tokens in
             await mockERC20.connect(user).approve(router.address, amount);
             await otherMockERC20.connect(user).approve(router.address, amount);
+
+            await expect(
+                router.connect(user).depositERC20Batch(
+                    vault.address,
+                    [mockERC20.address, otherMockERC20.address],
+                    [amount]
+                )
+            ).to.be.revertedWith("VDR_BatchLengthMismatch");
+
             await router.connect(user).depositERC20Batch(
                 vault.address,
                 [mockERC20.address, otherMockERC20.address],
@@ -325,6 +334,15 @@ describe("VaultDepositRouter", () => {
             // approve router to send ERC721 tokens in
             await mockERC721.connect(user).setApprovalForAll(router.address, true);
             await otherMockERC721.connect(user).approve(router.address, tokenId2);
+
+            await expect(
+                router.connect(user).depositERC721Batch(
+                    vault.address,
+                    [mockERC721.address, otherMockERC721.address, mockERC721.address],
+                    [tokenId, tokenId2]
+                )
+            ).to.be.revertedWith("VDR_BatchLengthMismatch");
+
             await router.connect(user).depositERC721Batch(
                 vault.address,
                 [mockERC721.address, otherMockERC721.address, mockERC721.address],
@@ -364,6 +382,35 @@ describe("VaultDepositRouter", () => {
             // approve router to send ERC1155 tokens in
             await mockERC1155.connect(user).setApprovalForAll(router.address, true);
             await otherMockERC1155.connect(user).setApprovalForAll(router.address, true);
+
+            await expect(
+                router.connect(user).depositERC1155Batch(
+                    vault.address,
+                    [mockERC1155.address, otherMockERC1155.address, mockERC1155.address],
+                    [tokenId, tokenId2, tokenId3],
+                    [amount, amount]
+                )
+            ).to.be.revertedWith("VDR_BatchLengthMismatch");
+
+            await expect(
+                router.connect(user).depositERC1155Batch(
+                    vault.address,
+                    [mockERC1155.address, otherMockERC1155.address, mockERC1155.address],
+                    [tokenId2, tokenId3],
+                    [amount, amount, amount]
+                )
+            ).to.be.revertedWith("VDR_BatchLengthMismatch");
+
+            await expect(
+                router.connect(user).depositERC1155Batch(
+                    vault.address,
+                    [mockERC1155.address, otherMockERC1155.address, mockERC1155.address],
+                    [tokenId, tokenId2, tokenId3],
+                    [amount, amount]
+                )
+            ).to.be.revertedWith("VDR_BatchLengthMismatch");
+
+
             await router.connect(user).depositERC1155Batch(
                 vault.address,
                 [mockERC1155.address, otherMockERC1155.address, mockERC1155.address],
@@ -404,6 +451,15 @@ describe("VaultDepositRouter", () => {
             // approve router to send a punk in
             await punks.connect(user).offerPunkForSaleToAddress(tokenId, 0, router.address);
             await punks.connect(user).offerPunkForSaleToAddress(tokenId2, 0, router.address);
+
+            await expect(
+                router.connect(user).depositPunkBatch(
+                    vault.address,
+                    [punks.address],
+                    [tokenId, tokenId2]
+                )
+            ).to.be.revertedWith("VDR_BatchLengthMismatch");
+
             await router.connect(user).depositPunkBatch(
                 vault.address,
                 [punks.address, punks.address],

--- a/test/VaultDepositRouter.ts
+++ b/test/VaultDepositRouter.ts
@@ -1,0 +1,768 @@
+import { expect } from "chai";
+import hre, { ethers, waffle, upgrades } from "hardhat";
+const { loadFixture } = waffle;
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { BigNumber, BigNumberish } from "ethers";
+
+import {
+    AssetVault,
+    CallWhitelist,
+    VaultFactory,
+    MockCallDelegator,
+    MockERC20,
+    MockERC721,
+    MockERC1155,
+    CryptoPunksMarket,
+    VaultInventoryReporter,
+    VaultDepositRouter
+} from "../typechain";
+import { mint, ZERO_ADDRESS } from "./utils/erc20";
+import { mint as mintERC721 } from "./utils/erc721";
+import { mint as mintERC1155 } from "./utils/erc1155";
+import { deploy } from "./utils/contracts";
+
+type Signer = SignerWithAddress;
+
+interface TestContext {
+    vault: AssetVault;
+    vaultTemplate: AssetVault;
+    nft: VaultFactory;
+    whitelist: CallWhitelist;
+    bundleId: BigNumberish;
+    mockERC20: MockERC20;
+    mockERC721: MockERC721;
+    mockERC1155: MockERC1155;
+    punks: CryptoPunksMarket;
+    reporter: VaultInventoryReporter;
+    router: VaultDepositRouter;
+    user: Signer;
+    other: Signer;
+    signers: Signer[];
+}
+
+describe("VaultDepositRouter", () => {
+    /**
+     * Creates a vault instance using the vault factory
+     */
+    const createVault = async (factory: VaultFactory, user: Signer): Promise<AssetVault> => {
+        const tx = await factory.connect(user).initializeBundle(await user.getAddress());
+        const receipt = await tx.wait();
+
+        let vault: AssetVault | undefined;
+        if (receipt && receipt.events) {
+            for (const event of receipt.events) {
+                if (event.args && event.args.vault) {
+                    vault = <AssetVault>await hre.ethers.getContractAt("AssetVault", event.args.vault);
+                }
+            }
+        } else {
+            throw new Error("Unable to create new vault");
+        }
+        if (!vault) {
+            throw new Error("Unable to create new vault");
+        }
+        return vault;
+    };
+
+    /**
+     * Sets up a test context, deploying new contracts and returning them for use in a test
+     */
+    const fixture = async (): Promise<TestContext> => {
+        const signers: Signer[] = await hre.ethers.getSigners();
+        const whitelist = <CallWhitelist>await deploy("CallWhitelist", signers[0], []);
+        const mockERC20 = <MockERC20>await deploy("MockERC20", signers[0], ["Mock ERC20", "MOCK"]);
+        const mockERC721 = <MockERC721>await deploy("MockERC721", signers[0], ["Mock ERC721", "MOCK"]);
+        const mockERC1155 = <MockERC1155>await deploy("MockERC1155", signers[0], []);
+
+        const vaultTemplate = <AssetVault>await deploy("AssetVault", signers[0], []);
+        const VaultFactoryFactory = await hre.ethers.getContractFactory("VaultFactory");
+        const factory = <VaultFactory>await upgrades.deployProxy(
+            VaultFactoryFactory,
+            [vaultTemplate.address, whitelist.address],
+            {
+                kind: "uups",
+            },
+        );
+        const vault = await createVault(factory, signers[0]);
+
+        const punks = <CryptoPunksMarket>await deploy("CryptoPunksMarket", signers[0], []);
+
+        const reporter = <VaultInventoryReporter>await deploy("VaultInventoryReporter", signers[0], []);
+        const router = <VaultDepositRouter>await deploy("VaultDepositRouter", signers[0], [factory.address, reporter.address]);
+
+        return {
+            nft: factory,
+            vault,
+            vaultTemplate,
+            whitelist,
+            bundleId: vault.address,
+            mockERC20,
+            mockERC721,
+            mockERC1155,
+            user: signers[0],
+            other: signers[1],
+            signers: signers.slice(2),
+            punks,
+            reporter,
+            router
+        };
+    };
+
+    describe("Deployment", () => {
+        it("should fail to deploy if deployed without a factory", async () => {
+            const { reporter } = await loadFixture(fixture);
+
+            const factory = await hre.ethers.getContractFactory("VaultDepositRouter");
+
+            await expect(factory.deploy(ZERO_ADDRESS, reporter.address)).to.be.revertedWith("VDR_ZeroAddress");
+        });
+
+        it("should fail to deploy if deployed without a reporter", async () => {
+            const { nft } = await loadFixture(fixture);
+
+            const factory = await hre.ethers.getContractFactory("VaultDepositRouter");
+
+            await expect(factory.deploy(nft.address, ZERO_ADDRESS)).to.be.revertedWith("VDR_ZeroAddress");
+        });
+    });
+
+    describe.only("Deposits", () => {
+        it("should not accept a deposit for a vault that does not exist");
+        it("should not accept a deposit if the user is not the owner of a vault");
+        it("should accept a deposit if the depositor has an approval from the owner");
+
+        it("should accept deposit from an ERC20 token and report inventory", async () => {
+            const { vault, mockERC20, user, router, reporter } = await loadFixture(fixture);
+            const amount = hre.ethers.utils.parseUnits("50", 18);
+
+            await mint(mockERC20, user, amount);
+            // approve router to send ERC20 tokens in
+            await mockERC20.connect(user).approve(router.address, amount);
+            await router.connect(user).depositERC20(vault.address, mockERC20.address, amount);
+
+            expect(await mockERC20.balanceOf(vault.address)).to.equal(amount);
+
+            // Expect reporter to show correct inventory
+            expect(await reporter.verify(vault.address)).to.eq(true);
+
+            const items = await reporter.enumerate(vault.address);
+
+            expect(items.length).to.eq(1);
+            expect(items[0].tokenAddress).to.eq(mockERC20.address);
+            expect(items[0].tokenAmount).to.eq(amount);
+        });
+
+        it("should accept deposit from an ERC721 token and report inventory", async () => {
+            const { vault, mockERC721, user, router, reporter } = await loadFixture(fixture);
+
+            const tokenId = await mintERC721(mockERC721, user);
+            console.log("ID 1", mockERC721.address, user.address, tokenId.toString(), router.address);
+
+            // approve router to send ERC721 tokens in
+            await mockERC721.connect(user).approve(router.address, tokenId);
+            console.log("Approved");
+            console.log("HERE:", await mockERC721.getApproved(tokenId));
+            await router.connect(user).depositERC721(vault.address, mockERC721.address, tokenId);
+            console.log("Done");
+
+            expect(await mockERC721.balanceOf(vault.address)).to.equal(1);
+            expect(await mockERC721.ownerOf(tokenId)).to.equal(vault.address);
+
+            // Expect reporter to show correct inventory
+            expect(await reporter.verify(vault.address)).to.eq(true);
+
+            const items = await reporter.enumerate(vault.address);
+
+            expect(items.length).to.eq(1);
+            expect(items[0].tokenAddress).to.eq(mockERC721.address);
+            expect(items[0].tokenId).to.eq(tokenId);
+        });
+
+        it("should accept deposit from an ERC1155 token and report inventory", async () => {
+            const { vault, mockERC1155, user, router, reporter } = await loadFixture(fixture);
+            const amount = hre.ethers.utils.parseUnits("50", 18);
+
+            const tokenId = await mintERC1155(mockERC1155, user, amount);
+            // approve router to send ERC20 tokens in
+            await mockERC1155.connect(user).setApprovalForAll(router.address, true);
+            await router.connect(user).depositERC1155(vault.address, mockERC1155.address, tokenId, amount);
+
+            expect(await mockERC1155.balanceOf(vault.address, tokenId)).to.equal(amount);
+
+            // Expect reporter to show correct inventory
+            expect(await reporter.verify(vault.address)).to.eq(true);
+
+            const items = await reporter.enumerate(vault.address);
+
+            expect(items.length).to.eq(1);
+            expect(items[0].tokenAddress).to.eq(mockERC1155.address);
+            expect(items[0].tokenId).to.eq(tokenId);
+            expect(items[0].tokenAmount).to.eq(amount);
+        });
+    });
+
+    describe("enableWithdraw", () => {
+        it("should close the vault", async () => {
+            const { vault, user } = await loadFixture(fixture);
+            expect(await vault.withdrawEnabled()).to.equal(false);
+            await expect(vault.enableWithdraw())
+                .to.emit(vault, "WithdrawEnabled")
+                .withArgs(await user.getAddress());
+
+            expect(await vault.withdrawEnabled()).to.equal(true);
+        });
+
+        it("should fail to close the vault by non-owner", async () => {
+            const { vault, other } = await loadFixture(fixture);
+            expect(await vault.withdrawEnabled()).to.equal(false);
+            await expect(vault.connect(other).enableWithdraw()).to.be.revertedWith("OERC721_CallerNotOwner");
+
+            expect(await vault.withdrawEnabled()).to.equal(false);
+        });
+    });
+
+    describe("call", async () => {
+        it("succeeds if current owner and on whitelist", async () => {
+            const { whitelist, vault, mockERC20, user } = await loadFixture(fixture);
+
+            const selector = mockERC20.interface.getSighash("mint");
+            const mintData = await mockERC20.populateTransaction.mint(
+                await user.getAddress(),
+                ethers.utils.parseEther("1"),
+            );
+            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
+
+            await whitelist.add(mockERC20.address, selector);
+
+            const startingBalance = await mockERC20.balanceOf(await user.getAddress());
+            await expect(vault.connect(user).call(mockERC20.address, mintData.data))
+                .to.emit(vault, "Call")
+                .withArgs(await user.getAddress(), mockERC20.address, mintData.data);
+            const endingBalance = await mockERC20.balanceOf(await user.getAddress());
+            expect(endingBalance.sub(startingBalance)).to.equal(ethers.utils.parseEther("1"));
+        });
+
+        it("succeeds if delegated and on whitelist", async () => {
+            const { nft, whitelist, vault, mockERC20, user, other } = await loadFixture(fixture);
+
+            const mockCallDelegator = <MockCallDelegator>await deploy("MockCallDelegator", other, []);
+            await mockCallDelegator.connect(other).setCanCall(true);
+
+            const selector = mockERC20.interface.getSighash("mint");
+            const mintData = await mockERC20.populateTransaction.mint(
+                await user.getAddress(),
+                ethers.utils.parseEther("1"),
+            );
+            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
+
+            // transfer the NFT to the call delegator (like using it as loan collateral)
+            await nft.transferFrom(await user.getAddress(), mockCallDelegator.address, vault.address);
+            await whitelist.add(mockERC20.address, selector);
+
+            const startingBalance = await mockERC20.balanceOf(await user.getAddress());
+            await expect(vault.connect(user).call(mockERC20.address, mintData.data))
+                .to.emit(vault, "Call")
+                .withArgs(await user.getAddress(), mockERC20.address, mintData.data);
+            const endingBalance = await mockERC20.balanceOf(await user.getAddress());
+            expect(endingBalance.sub(startingBalance)).to.equal(ethers.utils.parseEther("1"));
+        });
+
+        it("fails if withdraw enabled on vault", async () => {
+            const { whitelist, vault, mockERC20, user, other } = await loadFixture(fixture);
+
+            const mockCallDelegator = <MockCallDelegator>await deploy("MockCallDelegator", other, []);
+            await mockCallDelegator.connect(other).setCanCall(true);
+
+            const selector = mockERC20.interface.getSighash("mint");
+            const mintData = await mockERC20.populateTransaction.mint(
+                await user.getAddress(),
+                ethers.utils.parseEther("1"),
+            );
+            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
+
+            await whitelist.add(mockERC20.address, selector);
+
+            // enable withdraw on the vault
+            await vault.connect(user).enableWithdraw();
+
+            await expect(vault.connect(user).call(mockERC20.address, mintData.data)).to.be.revertedWith(
+                "AV_WithdrawsEnabled",
+            );
+        });
+
+        it("fails if delegator disallows", async () => {
+            const { nft, whitelist, vault, mockERC20, user, other } = await loadFixture(fixture);
+
+            const mockCallDelegator = <MockCallDelegator>await deploy("MockCallDelegator", other, []);
+            await mockCallDelegator.connect(other).setCanCall(false);
+
+            const selector = mockERC20.interface.getSighash("mint");
+            const mintData = await mockERC20.populateTransaction.mint(
+                await user.getAddress(),
+                ethers.utils.parseEther("1"),
+            );
+            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
+
+            // transfer the NFT to the call delegator (like using it as loan collateral)
+            await nft.transferFrom(await user.getAddress(), mockCallDelegator.address, vault.address);
+            await whitelist.add(mockERC20.address, selector);
+
+            await expect(vault.connect(user).call(mockERC20.address, mintData.data)).to.be.revertedWith(
+                "AV_CallDisallowed",
+            );
+        });
+
+        it("fails if delegator is EOA", async () => {
+            const { nft, whitelist, vault, mockERC20, user, other } = await loadFixture(fixture);
+
+            const mockCallDelegator = <MockCallDelegator>await deploy("MockCallDelegator", other, []);
+            await mockCallDelegator.connect(other).setCanCall(true);
+
+            const selector = mockERC20.interface.getSighash("mint(address,uint256)");
+
+            const mintData = await mockERC20.populateTransaction.mint(
+                await user.getAddress(),
+                ethers.utils.parseEther("1"),
+            );
+            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
+
+            // transfer the vault NFT to the call delegator (like using it as loan collateral)
+            await nft.transferFrom(await user.getAddress(), mockCallDelegator.address, vault.address);
+
+            await whitelist.add(await user.getAddress(), selector);
+
+            await expect(vault.connect(user).call(await user.getAddress(), mintData.data)).to.be.revertedWith(
+                "Address: call to non-contract",
+            );
+        });
+
+        it("fails if delegator is contract which doesn't support interface", async () => {
+            const { nft, whitelist, vault, mockERC20, user } = await loadFixture(fixture);
+
+            const selector = mockERC20.interface.getSighash("mint");
+            const mintData = await mockERC20.populateTransaction.mint(
+                await user.getAddress(),
+                ethers.utils.parseEther("1"),
+            );
+            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
+
+            // transfer the NFT to the call delegator (like using it as loan collateral)
+            await nft.transferFrom(await user.getAddress(), mockERC20.address, vault.address);
+            await whitelist.add(mockERC20.address, selector);
+
+            await expect(vault.connect(user).call(mockERC20.address, mintData.data)).to.be.revertedWith(
+                "Transaction reverted: function selector was not recognized and there's no fallback function",
+            );
+        });
+
+        it("fails from current owner if not whitelisted", async () => {
+            const { vault, mockERC20, user } = await loadFixture(fixture);
+
+            const mintData = await mockERC20.populateTransaction.mint(
+                await user.getAddress(),
+                ethers.utils.parseEther("1"),
+            );
+            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
+
+            await expect(vault.connect(user).call(mockERC20.address, mintData.data)).to.be.revertedWith(
+                "AV_NonWhitelistedCall",
+            );
+        });
+
+        it("fails if delegated and not whitelisted", async () => {
+            const { nft, vault, mockERC20, user, other } = await loadFixture(fixture);
+
+            const mockCallDelegator = <MockCallDelegator>await deploy("MockCallDelegator", other, []);
+            await mockCallDelegator.connect(other).setCanCall(true);
+
+            const mintData = await mockERC20.populateTransaction.mint(
+                await user.getAddress(),
+                ethers.utils.parseEther("1"),
+            );
+            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
+
+            await nft.transferFrom(await user.getAddress(), mockCallDelegator.address, vault.address);
+
+            await expect(vault.connect(user).call(mockERC20.address, mintData.data)).to.be.revertedWith(
+                "AV_NonWhitelistedCall",
+            );
+        });
+
+        it("fails if on global blacklist", async () => {
+            const { vault, mockERC20, user } = await loadFixture(fixture);
+
+            const transferData = await mockERC20.populateTransaction.transfer(
+                await user.getAddress(),
+                ethers.utils.parseEther("1"),
+            );
+            if (!transferData || !transferData.data) throw new Error("Populate transaction failed");
+
+            await expect(vault.connect(user).call(mockERC20.address, transferData.data)).to.be.revertedWith(
+                "AV_NonWhitelistedCall",
+            );
+        });
+
+        it("fails if on global blacklist even after whitelisting", async () => {
+            const { whitelist, vault, mockERC20, user } = await loadFixture(fixture);
+
+            const selector = mockERC20.interface.getSighash("transfer");
+            const transferData = await mockERC20.populateTransaction.transfer(
+                await user.getAddress(),
+                ethers.utils.parseEther("1"),
+            );
+            if (!transferData || !transferData.data) throw new Error("Populate transaction failed");
+
+            await whitelist.add(mockERC20.address, selector);
+
+            await expect(vault.connect(user).call(mockERC20.address, transferData.data)).to.be.revertedWith(
+                "AV_NonWhitelistedCall",
+            );
+        });
+
+        it("fails if address is on the whitelist but selector is not", async () => {
+            const { whitelist, vault, mockERC721, user } = await loadFixture(fixture);
+
+            const selector = mockERC721.interface.getSighash("burn");
+            const mintData = await mockERC721.populateTransaction.mint(await user.getAddress());
+            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
+
+            await whitelist.add(mockERC721.address, selector);
+
+            await expect(vault.connect(user).call(mockERC721.address, mintData.data)).to.be.revertedWith(
+                "AV_NonWhitelistedCall",
+            );
+        });
+
+        it("fails if selector is on the whitelist but address is not", async () => {
+            const { whitelist, vault, mockERC20, mockERC1155, user } = await loadFixture(fixture);
+
+            const selector = mockERC20.interface.getSighash("mint");
+            const mintData = await mockERC1155.populateTransaction.mint(
+                await user.getAddress(),
+                ethers.utils.parseEther("1"),
+            );
+            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
+
+            await whitelist.add(mockERC20.address, selector);
+
+            await expect(vault.connect(user).call(mockERC1155.address, mintData.data)).to.be.revertedWith(
+                "AV_NonWhitelistedCall",
+            );
+        });
+    });
+
+    describe("Withdraw", () => {
+        describe("ERC20", () => {
+            /**
+             * Set up a withdrawal test by depositing some ERC20s into a bundle
+             */
+            const deposit = async (token: MockERC20, vault: AssetVault, amount: BigNumber, user: Signer) => {
+                await mint(token, user, amount);
+                await token.connect(user).transfer(vault.address, amount);
+            };
+
+            it("should withdraw single deposit from a bundle", async () => {
+                const { vault, mockERC20, user } = await loadFixture(fixture);
+                const amount = hre.ethers.utils.parseUnits("50", 18);
+                await deposit(mockERC20, vault, amount, user);
+
+                await vault.connect(user).enableWithdraw();
+                await expect(vault.connect(user).withdrawERC20(mockERC20.address, await user.getAddress()))
+                    .to.emit(vault, "WithdrawERC20")
+                    .withArgs(await user.getAddress(), mockERC20.address, await user.getAddress(), amount)
+                    .to.emit(mockERC20, "Transfer")
+                    .withArgs(vault.address, await user.getAddress(), amount);
+            });
+
+            it("should withdraw single deposit from a bundle after transfer", async () => {
+                const { nft, bundleId, vault, mockERC20, user, other } = await loadFixture(fixture);
+                const amount = hre.ethers.utils.parseUnits("50", 18);
+                await deposit(mockERC20, vault, amount, user);
+                await nft["safeTransferFrom(address,address,uint256)"](
+                    await user.getAddress(),
+                    await other.getAddress(),
+                    bundleId,
+                );
+
+                await expect(vault.connect(other).enableWithdraw())
+                    .to.emit(vault, "WithdrawEnabled")
+                    .withArgs(await other.getAddress());
+                await expect(vault.connect(other).withdrawERC20(mockERC20.address, await other.getAddress()))
+                    .to.emit(vault, "WithdrawERC20")
+                    .withArgs(await other.getAddress(), mockERC20.address, await other.getAddress(), amount)
+                    .to.emit(mockERC20, "Transfer")
+                    .withArgs(bundleId, await other.getAddress(), amount);
+            });
+
+            it("should withdraw multiple deposits of the same token from a bundle", async () => {
+                const { vault, mockERC20, user } = await loadFixture(fixture);
+                const amount = hre.ethers.utils.parseUnits("50", 18);
+                await deposit(mockERC20, vault, amount, user);
+                const secondAmount = hre.ethers.utils.parseUnits("14", 18);
+                await deposit(mockERC20, vault, secondAmount, user);
+                const total = amount.add(secondAmount);
+
+                await vault.enableWithdraw();
+                await expect(vault.connect(user).withdrawERC20(mockERC20.address, await user.getAddress()))
+                    .to.emit(vault, "WithdrawERC20")
+                    .withArgs(await user.getAddress(), mockERC20.address, await user.getAddress(), total)
+                    .to.emit(mockERC20, "Transfer")
+                    .withArgs(vault.address, await user.getAddress(), total);
+            });
+
+            it("should withdraw deposits of multiple tokens from a bundle", async () => {
+                const { vault, user } = await loadFixture(fixture);
+                const amount = hre.ethers.utils.parseUnits("50", 18);
+
+                const tokens = [];
+                for (let i = 0; i < 10; i++) {
+                    const mockERC20 = <MockERC20>await deploy("MockERC20", user, ["Mock ERC20", "MOCK" + i]);
+                    await deposit(mockERC20, vault, amount, user);
+                    tokens.push(mockERC20);
+                }
+
+                await vault.enableWithdraw();
+                for (const token of tokens) {
+                    await expect(vault.connect(user).withdrawERC20(token.address, await user.getAddress()))
+                        .to.emit(vault, "WithdrawERC20")
+                        .withArgs(await user.getAddress(), token.address, await user.getAddress(), amount)
+                        .to.emit(token, "Transfer")
+                        .withArgs(vault.address, await user.getAddress(), amount);
+                }
+            });
+
+            it("should fail to withdraw when withdraws disabled", async () => {
+                const { vault, mockERC20, user } = await loadFixture(fixture);
+                const amount = hre.ethers.utils.parseUnits("50", 18);
+                await deposit(mockERC20, vault, amount, user);
+
+                await expect(
+                    vault.connect(user).withdrawERC20(mockERC20.address, await user.getAddress()),
+                ).to.be.revertedWith("AV_WithdrawsDisabled");
+            });
+
+            it("should fail to withdraw from non-owner", async () => {
+                const { vault, mockERC20, user, other } = await loadFixture(fixture);
+                const amount = hre.ethers.utils.parseUnits("50", 18);
+                await deposit(mockERC20, vault, amount, user);
+
+                await vault.enableWithdraw();
+                await expect(
+                    vault.connect(other).withdrawERC20(mockERC20.address, await user.getAddress()),
+                ).to.be.revertedWith("OERC721_CallerNotOwner");
+            });
+
+            it("should throw when withdraw called by non-owner", async () => {
+                const { vault, mockERC20, user, other } = await loadFixture(fixture);
+                const amount = hre.ethers.utils.parseUnits("50", 18);
+                await deposit(mockERC20, vault, amount, user);
+
+                await expect(
+                    vault.connect(other).withdrawERC20(mockERC20.address, await user.getAddress()),
+                ).to.be.revertedWith("OERC721_CallerNotOwner");
+            });
+
+            it("should fail when non-owner calls with approval", async () => {
+                const { nft, vault, mockERC20, user, other } = await loadFixture(fixture);
+
+                await nft.connect(user).approve(await other.getAddress(), vault.address);
+                await expect(
+                    vault.connect(other).withdrawERC20(mockERC20.address, await user.getAddress()),
+                ).to.be.revertedWith("OERC721_CallerNotOwner");
+            });
+        });
+
+        describe("ERC721", () => {
+            /**
+             * Set up a withdrawal test by depositing some ERC721s into a bundle
+             */
+            const deposit = async (token: MockERC721, vault: AssetVault, user: Signer) => {
+                const tokenId = await mintERC721(token, user);
+                await token["safeTransferFrom(address,address,uint256)"](
+                    await user.getAddress(),
+                    vault.address,
+                    tokenId,
+                );
+                return tokenId;
+            };
+
+            it("should withdraw single deposit from a bundle", async () => {
+                const { vault, mockERC721, user } = await loadFixture(fixture);
+                const tokenId = await deposit(mockERC721, vault, user);
+
+                await vault.enableWithdraw();
+                await expect(vault.connect(user).withdrawERC721(mockERC721.address, tokenId, await user.getAddress()))
+                    .to.emit(vault, "WithdrawERC721")
+                    .withArgs(await user.getAddress(), mockERC721.address, await user.getAddress(), tokenId)
+                    .to.emit(mockERC721, "Transfer")
+                    .withArgs(vault.address, await user.getAddress(), tokenId);
+            });
+
+            it("should withdraw a CryptoPunk from a vault", async () => {
+                const { vault, punks, user } = await loadFixture(fixture);
+                const punkIndex = 1234;
+                // claim ownership of punk
+                await punks.setInitialOwner(await user.getAddress(), punkIndex);
+                await punks.allInitialOwnersAssigned();
+                // "approve" the punk to the vault
+                await punks.offerPunkForSaleToAddress(punkIndex, 0, vault.address);
+                // deposit the punk into the vault
+                await punks.transferPunk(vault.address, punkIndex);
+
+                await vault.enableWithdraw();
+                await expect(vault.connect(user).withdrawPunk(punks.address, punkIndex, await user.getAddress()))
+                    .to.emit(punks, "Transfer")
+                    .withArgs(vault.address, await user.getAddress(), 1)
+                    .to.emit(punks, "PunkTransfer")
+                    .withArgs(vault.address, await user.getAddress(), punkIndex);
+            });
+
+            it("should throw when already withdrawn", async () => {
+                const { vault, mockERC721, user } = await loadFixture(fixture);
+                const tokenId = await deposit(mockERC721, vault, user);
+
+                await vault.enableWithdraw();
+                await expect(vault.connect(user).withdrawERC721(mockERC721.address, tokenId, await user.getAddress()))
+                    .to.emit(vault, "WithdrawERC721")
+                    .withArgs(await user.getAddress(), mockERC721.address, await user.getAddress(), tokenId)
+                    .to.emit(mockERC721, "Transfer")
+                    .withArgs(vault.address, await user.getAddress(), tokenId);
+
+                await expect(
+                    vault.connect(user).withdrawERC721(mockERC721.address, tokenId, await user.getAddress()),
+                ).to.be.revertedWith("ERC721: transfer caller is not owner nor approved");
+            });
+
+            it("should throw when withdraw called by non-owner", async () => {
+                const { vault, mockERC721, user, other } = await loadFixture(fixture);
+                const tokenId = await deposit(mockERC721, vault, user);
+
+                await vault.enableWithdraw();
+                await expect(
+                    vault.connect(other).withdrawERC721(mockERC721.address, tokenId, await user.getAddress()),
+                ).to.be.revertedWith("OERC721_CallerNotOwner");
+            });
+
+            it("should fail to withdraw when withdraws disabled", async () => {
+                const { vault, mockERC721, user } = await loadFixture(fixture);
+                const tokenId = await deposit(mockERC721, vault, user);
+
+                await expect(
+                    vault.connect(user).withdrawERC721(mockERC721.address, tokenId, await user.getAddress()),
+                ).to.be.revertedWith("AV_WithdrawsDisabled");
+            });
+        });
+
+        describe("ERC1155", () => {
+            /**
+             * Set up a withdrawal test by depositing some ERC1155s into a bundle
+             */
+            const deposit = async (token: MockERC1155, vault: AssetVault, user: Signer, amount: BigNumber) => {
+                const tokenId = await mintERC1155(token, user, amount);
+                await token.safeTransferFrom(await user.getAddress(), vault.address, tokenId, amount, "0x");
+                return tokenId;
+            };
+
+            it("should withdraw single deposit from a bundle", async () => {
+                const { vault, mockERC1155, user } = await loadFixture(fixture);
+                const amount = BigNumber.from("1");
+                const tokenId = await deposit(mockERC1155, vault, user, amount);
+
+                await vault.enableWithdraw();
+                await expect(vault.connect(user).withdrawERC1155(mockERC1155.address, tokenId, await user.getAddress()))
+                    .to.emit(vault, "WithdrawERC1155")
+                    .withArgs(await user.getAddress(), mockERC1155.address, await user.getAddress(), tokenId, amount)
+                    .to.emit(mockERC1155, "TransferSingle")
+                    .withArgs(vault.address, vault.address, await user.getAddress(), tokenId, amount);
+            });
+
+            it("should withdraw fungible deposit from a bundle", async () => {
+                const { vault, mockERC1155, user } = await loadFixture(fixture);
+                const amount = hre.ethers.utils.parseEther("100");
+                const tokenId = await deposit(mockERC1155, vault, user, amount);
+
+                await vault.enableWithdraw();
+                await expect(vault.connect(user).withdrawERC1155(mockERC1155.address, tokenId, await user.getAddress()))
+                    .to.emit(vault, "WithdrawERC1155")
+                    .withArgs(await user.getAddress(), mockERC1155.address, await user.getAddress(), tokenId, amount)
+                    .to.emit(mockERC1155, "TransferSingle")
+                    .withArgs(vault.address, vault.address, await user.getAddress(), tokenId, amount);
+            });
+
+            it("should fail to withdraw when withdraws disabled", async () => {
+                const { vault, mockERC1155, user } = await loadFixture(fixture);
+                const amount = hre.ethers.utils.parseEther("100");
+                const tokenId = await deposit(mockERC1155, vault, user, amount);
+
+                await expect(
+                    vault.connect(user).withdrawERC1155(mockERC1155.address, tokenId, await user.getAddress()),
+                ).to.be.revertedWith("AV_WithdrawsDisabled");
+            });
+
+            it("should throw when withdraw called by non-owner", async () => {
+                const { vault, mockERC1155, user, other } = await loadFixture(fixture);
+                const amount = BigNumber.from("1");
+                const tokenId = await deposit(mockERC1155, vault, user, amount);
+
+                await vault.enableWithdraw();
+                await expect(
+                    vault.connect(other).withdrawERC1155(mockERC1155.address, tokenId, await other.getAddress()),
+                ).to.be.revertedWith("OERC721_CallerNotOwner");
+            });
+        });
+
+        describe("ETH", () => {
+            const deposit = async (vault: AssetVault, user: Signer, amount: BigNumber) => {
+                await user.sendTransaction({
+                    to: vault.address,
+                    value: amount,
+                });
+            };
+
+            it("should withdraw single deposit from a bundle", async () => {
+                const { vault, user } = await loadFixture(fixture);
+                const amount = hre.ethers.utils.parseEther("123");
+                await deposit(vault, user, amount);
+                const startingBalance = await vault.provider.getBalance(await user.getAddress());
+
+                await vault.enableWithdraw();
+                await expect(vault.connect(user).withdrawETH(await user.getAddress()))
+                    .to.emit(vault, "WithdrawETH")
+                    .withArgs(await user.getAddress(), await user.getAddress(), amount);
+
+                const threshold = hre.ethers.utils.parseEther("0.01"); // for txn fee
+                const endingBalance = await vault.provider.getBalance(await user.getAddress());
+                expect(endingBalance.sub(startingBalance).gt(amount.sub(threshold))).to.be.true;
+            });
+
+            it("should fail to withdraw when withdraws disabled", async () => {
+                const { vault, user } = await loadFixture(fixture);
+                const amount = hre.ethers.utils.parseEther("123");
+                await deposit(vault, user, amount);
+
+                await expect(vault.connect(user).withdrawETH(await user.getAddress())).to.be.revertedWith(
+                    "AV_WithdrawsDisabled",
+                );
+            });
+
+            it("should throw when withdraw called by non-owner", async () => {
+                const { vault, user, other } = await loadFixture(fixture);
+                const amount = hre.ethers.utils.parseEther("9");
+                await deposit(vault, user, amount);
+
+                await expect(vault.connect(other).withdrawETH(await other.getAddress())).to.be.revertedWith(
+                    "OERC721_CallerNotOwner",
+                );
+            });
+        });
+
+        describe("Introspection", function () {
+            it("should return true for declaring support for eip165 interface contract", async () => {
+                const { nft } = await loadFixture(fixture);
+                // https://eips.ethereum.org/EIPS/eip-165#test-cases
+                expect(await nft.supportsInterface("0x01ffc9a7")).to.be.true;
+                expect(await nft.supportsInterface("0xfafafafa")).to.be.false;
+            });
+        });
+    });
+});

--- a/test/VaultDepositRouter.ts
+++ b/test/VaultDepositRouter.ts
@@ -1,8 +1,11 @@
-import { expect } from "chai";
+import chai, { expect } from "chai";
 import hre, { ethers, waffle, upgrades } from "hardhat";
+import { solidity } from "ethereum-waffle";
 const { loadFixture } = waffle;
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
 import { BigNumber, BigNumberish } from "ethers";
+
+chai.use(solidity);
 
 import {
     AssetVault,
@@ -127,9 +130,69 @@ describe("VaultDepositRouter", () => {
     });
 
     describe.only("Deposits", () => {
-        it("should not accept a deposit for a vault that does not exist");
-        it("should not accept a deposit if the user is not the owner of a vault");
-        it("should accept a deposit if the depositor has an approval from the owner");
+        it("should not accept a deposit for the zero address", async () => {
+            const { mockERC20, user, router } = await loadFixture(fixture);
+            const amount = hre.ethers.utils.parseUnits("50", 18);
+
+            await mint(mockERC20, user, amount);
+            // approve router to send ERC20 tokens in
+            await mockERC20.connect(user).approve(router.address, amount);
+
+            // Reporter address not a valid vault
+            await expect(
+                router.connect(user).depositERC20(ZERO_ADDRESS, mockERC20.address, amount)
+            ).to.be.revertedWith("VDR_ZeroAddress");
+        });
+
+        it("should not accept a deposit for a vault that does not exist", async () => {
+            const { mockERC20, user, router, reporter } = await loadFixture(fixture);
+            const amount = hre.ethers.utils.parseUnits("50", 18);
+
+            await mint(mockERC20, user, amount);
+            // approve router to send ERC20 tokens in
+            await mockERC20.connect(user).approve(router.address, amount);
+
+            // Reporter address not a valid vault
+            await expect(
+                router.connect(user).depositERC20(reporter.address, mockERC20.address, amount)
+            ).to.be.revertedWith("VDR_InvalidVault");
+        });
+
+        it("should not accept a deposit if the user is not the owner of a vault", async () => {
+            const { vault, mockERC20, user, other, router } = await loadFixture(fixture);
+            const amount = hre.ethers.utils.parseUnits("50", 18);
+
+            await mint(mockERC20, user, amount);
+            // approve router to send ERC20 tokens in
+            await mockERC20.connect(user).approve(router.address, amount);
+
+            // Reporter address not a valid vault
+            await expect(
+                router.connect(other).depositERC20(vault.address, mockERC20.address, amount)
+            ).to.be.revertedWith("VDR_NotOwnerOrApproved");
+        });
+
+        it("should accept a deposit if the depositor has an approval from the owner", async () => {
+            const { nft, vault, mockERC20, user, other, router, reporter } = await loadFixture(fixture);
+            const amount = hre.ethers.utils.parseUnits("50", 18);
+
+            await mint(mockERC20, other, amount);
+            // approve router to send ERC20 tokens in
+            await mockERC20.connect(other).approve(router.address, amount);
+            await nft.connect(user).approve(other.address, vault.address);
+            await router.connect(other).depositERC20(vault.address, mockERC20.address, amount);
+
+            expect(await mockERC20.balanceOf(vault.address)).to.equal(amount);
+
+            // Expect reporter to show correct inventory
+            expect(await reporter.verify(vault.address)).to.eq(true);
+
+            const items = await reporter.enumerate(vault.address);
+
+            expect(items.length).to.eq(1);
+            expect(items[0].tokenAddress).to.eq(mockERC20.address);
+            expect(items[0].tokenAmount).to.eq(amount);
+        });
 
         it("should accept deposit from an ERC20 token and report inventory", async () => {
             const { vault, mockERC20, user, router, reporter } = await loadFixture(fixture);
@@ -156,14 +219,10 @@ describe("VaultDepositRouter", () => {
             const { vault, mockERC721, user, router, reporter } = await loadFixture(fixture);
 
             const tokenId = await mintERC721(mockERC721, user);
-            console.log("ID 1", mockERC721.address, user.address, tokenId.toString(), router.address);
 
             // approve router to send ERC721 tokens in
             await mockERC721.connect(user).approve(router.address, tokenId);
-            console.log("Approved");
-            console.log("HERE:", await mockERC721.getApproved(tokenId));
             await router.connect(user).depositERC721(vault.address, mockERC721.address, tokenId);
-            console.log("Done");
 
             expect(await mockERC721.balanceOf(vault.address)).to.equal(1);
             expect(await mockERC721.ownerOf(tokenId)).to.equal(vault.address);
@@ -198,571 +257,6 @@ describe("VaultDepositRouter", () => {
             expect(items[0].tokenAddress).to.eq(mockERC1155.address);
             expect(items[0].tokenId).to.eq(tokenId);
             expect(items[0].tokenAmount).to.eq(amount);
-        });
-    });
-
-    describe("enableWithdraw", () => {
-        it("should close the vault", async () => {
-            const { vault, user } = await loadFixture(fixture);
-            expect(await vault.withdrawEnabled()).to.equal(false);
-            await expect(vault.enableWithdraw())
-                .to.emit(vault, "WithdrawEnabled")
-                .withArgs(await user.getAddress());
-
-            expect(await vault.withdrawEnabled()).to.equal(true);
-        });
-
-        it("should fail to close the vault by non-owner", async () => {
-            const { vault, other } = await loadFixture(fixture);
-            expect(await vault.withdrawEnabled()).to.equal(false);
-            await expect(vault.connect(other).enableWithdraw()).to.be.revertedWith("OERC721_CallerNotOwner");
-
-            expect(await vault.withdrawEnabled()).to.equal(false);
-        });
-    });
-
-    describe("call", async () => {
-        it("succeeds if current owner and on whitelist", async () => {
-            const { whitelist, vault, mockERC20, user } = await loadFixture(fixture);
-
-            const selector = mockERC20.interface.getSighash("mint");
-            const mintData = await mockERC20.populateTransaction.mint(
-                await user.getAddress(),
-                ethers.utils.parseEther("1"),
-            );
-            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
-
-            await whitelist.add(mockERC20.address, selector);
-
-            const startingBalance = await mockERC20.balanceOf(await user.getAddress());
-            await expect(vault.connect(user).call(mockERC20.address, mintData.data))
-                .to.emit(vault, "Call")
-                .withArgs(await user.getAddress(), mockERC20.address, mintData.data);
-            const endingBalance = await mockERC20.balanceOf(await user.getAddress());
-            expect(endingBalance.sub(startingBalance)).to.equal(ethers.utils.parseEther("1"));
-        });
-
-        it("succeeds if delegated and on whitelist", async () => {
-            const { nft, whitelist, vault, mockERC20, user, other } = await loadFixture(fixture);
-
-            const mockCallDelegator = <MockCallDelegator>await deploy("MockCallDelegator", other, []);
-            await mockCallDelegator.connect(other).setCanCall(true);
-
-            const selector = mockERC20.interface.getSighash("mint");
-            const mintData = await mockERC20.populateTransaction.mint(
-                await user.getAddress(),
-                ethers.utils.parseEther("1"),
-            );
-            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
-
-            // transfer the NFT to the call delegator (like using it as loan collateral)
-            await nft.transferFrom(await user.getAddress(), mockCallDelegator.address, vault.address);
-            await whitelist.add(mockERC20.address, selector);
-
-            const startingBalance = await mockERC20.balanceOf(await user.getAddress());
-            await expect(vault.connect(user).call(mockERC20.address, mintData.data))
-                .to.emit(vault, "Call")
-                .withArgs(await user.getAddress(), mockERC20.address, mintData.data);
-            const endingBalance = await mockERC20.balanceOf(await user.getAddress());
-            expect(endingBalance.sub(startingBalance)).to.equal(ethers.utils.parseEther("1"));
-        });
-
-        it("fails if withdraw enabled on vault", async () => {
-            const { whitelist, vault, mockERC20, user, other } = await loadFixture(fixture);
-
-            const mockCallDelegator = <MockCallDelegator>await deploy("MockCallDelegator", other, []);
-            await mockCallDelegator.connect(other).setCanCall(true);
-
-            const selector = mockERC20.interface.getSighash("mint");
-            const mintData = await mockERC20.populateTransaction.mint(
-                await user.getAddress(),
-                ethers.utils.parseEther("1"),
-            );
-            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
-
-            await whitelist.add(mockERC20.address, selector);
-
-            // enable withdraw on the vault
-            await vault.connect(user).enableWithdraw();
-
-            await expect(vault.connect(user).call(mockERC20.address, mintData.data)).to.be.revertedWith(
-                "AV_WithdrawsEnabled",
-            );
-        });
-
-        it("fails if delegator disallows", async () => {
-            const { nft, whitelist, vault, mockERC20, user, other } = await loadFixture(fixture);
-
-            const mockCallDelegator = <MockCallDelegator>await deploy("MockCallDelegator", other, []);
-            await mockCallDelegator.connect(other).setCanCall(false);
-
-            const selector = mockERC20.interface.getSighash("mint");
-            const mintData = await mockERC20.populateTransaction.mint(
-                await user.getAddress(),
-                ethers.utils.parseEther("1"),
-            );
-            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
-
-            // transfer the NFT to the call delegator (like using it as loan collateral)
-            await nft.transferFrom(await user.getAddress(), mockCallDelegator.address, vault.address);
-            await whitelist.add(mockERC20.address, selector);
-
-            await expect(vault.connect(user).call(mockERC20.address, mintData.data)).to.be.revertedWith(
-                "AV_CallDisallowed",
-            );
-        });
-
-        it("fails if delegator is EOA", async () => {
-            const { nft, whitelist, vault, mockERC20, user, other } = await loadFixture(fixture);
-
-            const mockCallDelegator = <MockCallDelegator>await deploy("MockCallDelegator", other, []);
-            await mockCallDelegator.connect(other).setCanCall(true);
-
-            const selector = mockERC20.interface.getSighash("mint(address,uint256)");
-
-            const mintData = await mockERC20.populateTransaction.mint(
-                await user.getAddress(),
-                ethers.utils.parseEther("1"),
-            );
-            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
-
-            // transfer the vault NFT to the call delegator (like using it as loan collateral)
-            await nft.transferFrom(await user.getAddress(), mockCallDelegator.address, vault.address);
-
-            await whitelist.add(await user.getAddress(), selector);
-
-            await expect(vault.connect(user).call(await user.getAddress(), mintData.data)).to.be.revertedWith(
-                "Address: call to non-contract",
-            );
-        });
-
-        it("fails if delegator is contract which doesn't support interface", async () => {
-            const { nft, whitelist, vault, mockERC20, user } = await loadFixture(fixture);
-
-            const selector = mockERC20.interface.getSighash("mint");
-            const mintData = await mockERC20.populateTransaction.mint(
-                await user.getAddress(),
-                ethers.utils.parseEther("1"),
-            );
-            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
-
-            // transfer the NFT to the call delegator (like using it as loan collateral)
-            await nft.transferFrom(await user.getAddress(), mockERC20.address, vault.address);
-            await whitelist.add(mockERC20.address, selector);
-
-            await expect(vault.connect(user).call(mockERC20.address, mintData.data)).to.be.revertedWith(
-                "Transaction reverted: function selector was not recognized and there's no fallback function",
-            );
-        });
-
-        it("fails from current owner if not whitelisted", async () => {
-            const { vault, mockERC20, user } = await loadFixture(fixture);
-
-            const mintData = await mockERC20.populateTransaction.mint(
-                await user.getAddress(),
-                ethers.utils.parseEther("1"),
-            );
-            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
-
-            await expect(vault.connect(user).call(mockERC20.address, mintData.data)).to.be.revertedWith(
-                "AV_NonWhitelistedCall",
-            );
-        });
-
-        it("fails if delegated and not whitelisted", async () => {
-            const { nft, vault, mockERC20, user, other } = await loadFixture(fixture);
-
-            const mockCallDelegator = <MockCallDelegator>await deploy("MockCallDelegator", other, []);
-            await mockCallDelegator.connect(other).setCanCall(true);
-
-            const mintData = await mockERC20.populateTransaction.mint(
-                await user.getAddress(),
-                ethers.utils.parseEther("1"),
-            );
-            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
-
-            await nft.transferFrom(await user.getAddress(), mockCallDelegator.address, vault.address);
-
-            await expect(vault.connect(user).call(mockERC20.address, mintData.data)).to.be.revertedWith(
-                "AV_NonWhitelistedCall",
-            );
-        });
-
-        it("fails if on global blacklist", async () => {
-            const { vault, mockERC20, user } = await loadFixture(fixture);
-
-            const transferData = await mockERC20.populateTransaction.transfer(
-                await user.getAddress(),
-                ethers.utils.parseEther("1"),
-            );
-            if (!transferData || !transferData.data) throw new Error("Populate transaction failed");
-
-            await expect(vault.connect(user).call(mockERC20.address, transferData.data)).to.be.revertedWith(
-                "AV_NonWhitelistedCall",
-            );
-        });
-
-        it("fails if on global blacklist even after whitelisting", async () => {
-            const { whitelist, vault, mockERC20, user } = await loadFixture(fixture);
-
-            const selector = mockERC20.interface.getSighash("transfer");
-            const transferData = await mockERC20.populateTransaction.transfer(
-                await user.getAddress(),
-                ethers.utils.parseEther("1"),
-            );
-            if (!transferData || !transferData.data) throw new Error("Populate transaction failed");
-
-            await whitelist.add(mockERC20.address, selector);
-
-            await expect(vault.connect(user).call(mockERC20.address, transferData.data)).to.be.revertedWith(
-                "AV_NonWhitelistedCall",
-            );
-        });
-
-        it("fails if address is on the whitelist but selector is not", async () => {
-            const { whitelist, vault, mockERC721, user } = await loadFixture(fixture);
-
-            const selector = mockERC721.interface.getSighash("burn");
-            const mintData = await mockERC721.populateTransaction.mint(await user.getAddress());
-            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
-
-            await whitelist.add(mockERC721.address, selector);
-
-            await expect(vault.connect(user).call(mockERC721.address, mintData.data)).to.be.revertedWith(
-                "AV_NonWhitelistedCall",
-            );
-        });
-
-        it("fails if selector is on the whitelist but address is not", async () => {
-            const { whitelist, vault, mockERC20, mockERC1155, user } = await loadFixture(fixture);
-
-            const selector = mockERC20.interface.getSighash("mint");
-            const mintData = await mockERC1155.populateTransaction.mint(
-                await user.getAddress(),
-                ethers.utils.parseEther("1"),
-            );
-            if (!mintData || !mintData.data) throw new Error("Populate transaction failed");
-
-            await whitelist.add(mockERC20.address, selector);
-
-            await expect(vault.connect(user).call(mockERC1155.address, mintData.data)).to.be.revertedWith(
-                "AV_NonWhitelistedCall",
-            );
-        });
-    });
-
-    describe("Withdraw", () => {
-        describe("ERC20", () => {
-            /**
-             * Set up a withdrawal test by depositing some ERC20s into a bundle
-             */
-            const deposit = async (token: MockERC20, vault: AssetVault, amount: BigNumber, user: Signer) => {
-                await mint(token, user, amount);
-                await token.connect(user).transfer(vault.address, amount);
-            };
-
-            it("should withdraw single deposit from a bundle", async () => {
-                const { vault, mockERC20, user } = await loadFixture(fixture);
-                const amount = hre.ethers.utils.parseUnits("50", 18);
-                await deposit(mockERC20, vault, amount, user);
-
-                await vault.connect(user).enableWithdraw();
-                await expect(vault.connect(user).withdrawERC20(mockERC20.address, await user.getAddress()))
-                    .to.emit(vault, "WithdrawERC20")
-                    .withArgs(await user.getAddress(), mockERC20.address, await user.getAddress(), amount)
-                    .to.emit(mockERC20, "Transfer")
-                    .withArgs(vault.address, await user.getAddress(), amount);
-            });
-
-            it("should withdraw single deposit from a bundle after transfer", async () => {
-                const { nft, bundleId, vault, mockERC20, user, other } = await loadFixture(fixture);
-                const amount = hre.ethers.utils.parseUnits("50", 18);
-                await deposit(mockERC20, vault, amount, user);
-                await nft["safeTransferFrom(address,address,uint256)"](
-                    await user.getAddress(),
-                    await other.getAddress(),
-                    bundleId,
-                );
-
-                await expect(vault.connect(other).enableWithdraw())
-                    .to.emit(vault, "WithdrawEnabled")
-                    .withArgs(await other.getAddress());
-                await expect(vault.connect(other).withdrawERC20(mockERC20.address, await other.getAddress()))
-                    .to.emit(vault, "WithdrawERC20")
-                    .withArgs(await other.getAddress(), mockERC20.address, await other.getAddress(), amount)
-                    .to.emit(mockERC20, "Transfer")
-                    .withArgs(bundleId, await other.getAddress(), amount);
-            });
-
-            it("should withdraw multiple deposits of the same token from a bundle", async () => {
-                const { vault, mockERC20, user } = await loadFixture(fixture);
-                const amount = hre.ethers.utils.parseUnits("50", 18);
-                await deposit(mockERC20, vault, amount, user);
-                const secondAmount = hre.ethers.utils.parseUnits("14", 18);
-                await deposit(mockERC20, vault, secondAmount, user);
-                const total = amount.add(secondAmount);
-
-                await vault.enableWithdraw();
-                await expect(vault.connect(user).withdrawERC20(mockERC20.address, await user.getAddress()))
-                    .to.emit(vault, "WithdrawERC20")
-                    .withArgs(await user.getAddress(), mockERC20.address, await user.getAddress(), total)
-                    .to.emit(mockERC20, "Transfer")
-                    .withArgs(vault.address, await user.getAddress(), total);
-            });
-
-            it("should withdraw deposits of multiple tokens from a bundle", async () => {
-                const { vault, user } = await loadFixture(fixture);
-                const amount = hre.ethers.utils.parseUnits("50", 18);
-
-                const tokens = [];
-                for (let i = 0; i < 10; i++) {
-                    const mockERC20 = <MockERC20>await deploy("MockERC20", user, ["Mock ERC20", "MOCK" + i]);
-                    await deposit(mockERC20, vault, amount, user);
-                    tokens.push(mockERC20);
-                }
-
-                await vault.enableWithdraw();
-                for (const token of tokens) {
-                    await expect(vault.connect(user).withdrawERC20(token.address, await user.getAddress()))
-                        .to.emit(vault, "WithdrawERC20")
-                        .withArgs(await user.getAddress(), token.address, await user.getAddress(), amount)
-                        .to.emit(token, "Transfer")
-                        .withArgs(vault.address, await user.getAddress(), amount);
-                }
-            });
-
-            it("should fail to withdraw when withdraws disabled", async () => {
-                const { vault, mockERC20, user } = await loadFixture(fixture);
-                const amount = hre.ethers.utils.parseUnits("50", 18);
-                await deposit(mockERC20, vault, amount, user);
-
-                await expect(
-                    vault.connect(user).withdrawERC20(mockERC20.address, await user.getAddress()),
-                ).to.be.revertedWith("AV_WithdrawsDisabled");
-            });
-
-            it("should fail to withdraw from non-owner", async () => {
-                const { vault, mockERC20, user, other } = await loadFixture(fixture);
-                const amount = hre.ethers.utils.parseUnits("50", 18);
-                await deposit(mockERC20, vault, amount, user);
-
-                await vault.enableWithdraw();
-                await expect(
-                    vault.connect(other).withdrawERC20(mockERC20.address, await user.getAddress()),
-                ).to.be.revertedWith("OERC721_CallerNotOwner");
-            });
-
-            it("should throw when withdraw called by non-owner", async () => {
-                const { vault, mockERC20, user, other } = await loadFixture(fixture);
-                const amount = hre.ethers.utils.parseUnits("50", 18);
-                await deposit(mockERC20, vault, amount, user);
-
-                await expect(
-                    vault.connect(other).withdrawERC20(mockERC20.address, await user.getAddress()),
-                ).to.be.revertedWith("OERC721_CallerNotOwner");
-            });
-
-            it("should fail when non-owner calls with approval", async () => {
-                const { nft, vault, mockERC20, user, other } = await loadFixture(fixture);
-
-                await nft.connect(user).approve(await other.getAddress(), vault.address);
-                await expect(
-                    vault.connect(other).withdrawERC20(mockERC20.address, await user.getAddress()),
-                ).to.be.revertedWith("OERC721_CallerNotOwner");
-            });
-        });
-
-        describe("ERC721", () => {
-            /**
-             * Set up a withdrawal test by depositing some ERC721s into a bundle
-             */
-            const deposit = async (token: MockERC721, vault: AssetVault, user: Signer) => {
-                const tokenId = await mintERC721(token, user);
-                await token["safeTransferFrom(address,address,uint256)"](
-                    await user.getAddress(),
-                    vault.address,
-                    tokenId,
-                );
-                return tokenId;
-            };
-
-            it("should withdraw single deposit from a bundle", async () => {
-                const { vault, mockERC721, user } = await loadFixture(fixture);
-                const tokenId = await deposit(mockERC721, vault, user);
-
-                await vault.enableWithdraw();
-                await expect(vault.connect(user).withdrawERC721(mockERC721.address, tokenId, await user.getAddress()))
-                    .to.emit(vault, "WithdrawERC721")
-                    .withArgs(await user.getAddress(), mockERC721.address, await user.getAddress(), tokenId)
-                    .to.emit(mockERC721, "Transfer")
-                    .withArgs(vault.address, await user.getAddress(), tokenId);
-            });
-
-            it("should withdraw a CryptoPunk from a vault", async () => {
-                const { vault, punks, user } = await loadFixture(fixture);
-                const punkIndex = 1234;
-                // claim ownership of punk
-                await punks.setInitialOwner(await user.getAddress(), punkIndex);
-                await punks.allInitialOwnersAssigned();
-                // "approve" the punk to the vault
-                await punks.offerPunkForSaleToAddress(punkIndex, 0, vault.address);
-                // deposit the punk into the vault
-                await punks.transferPunk(vault.address, punkIndex);
-
-                await vault.enableWithdraw();
-                await expect(vault.connect(user).withdrawPunk(punks.address, punkIndex, await user.getAddress()))
-                    .to.emit(punks, "Transfer")
-                    .withArgs(vault.address, await user.getAddress(), 1)
-                    .to.emit(punks, "PunkTransfer")
-                    .withArgs(vault.address, await user.getAddress(), punkIndex);
-            });
-
-            it("should throw when already withdrawn", async () => {
-                const { vault, mockERC721, user } = await loadFixture(fixture);
-                const tokenId = await deposit(mockERC721, vault, user);
-
-                await vault.enableWithdraw();
-                await expect(vault.connect(user).withdrawERC721(mockERC721.address, tokenId, await user.getAddress()))
-                    .to.emit(vault, "WithdrawERC721")
-                    .withArgs(await user.getAddress(), mockERC721.address, await user.getAddress(), tokenId)
-                    .to.emit(mockERC721, "Transfer")
-                    .withArgs(vault.address, await user.getAddress(), tokenId);
-
-                await expect(
-                    vault.connect(user).withdrawERC721(mockERC721.address, tokenId, await user.getAddress()),
-                ).to.be.revertedWith("ERC721: transfer caller is not owner nor approved");
-            });
-
-            it("should throw when withdraw called by non-owner", async () => {
-                const { vault, mockERC721, user, other } = await loadFixture(fixture);
-                const tokenId = await deposit(mockERC721, vault, user);
-
-                await vault.enableWithdraw();
-                await expect(
-                    vault.connect(other).withdrawERC721(mockERC721.address, tokenId, await user.getAddress()),
-                ).to.be.revertedWith("OERC721_CallerNotOwner");
-            });
-
-            it("should fail to withdraw when withdraws disabled", async () => {
-                const { vault, mockERC721, user } = await loadFixture(fixture);
-                const tokenId = await deposit(mockERC721, vault, user);
-
-                await expect(
-                    vault.connect(user).withdrawERC721(mockERC721.address, tokenId, await user.getAddress()),
-                ).to.be.revertedWith("AV_WithdrawsDisabled");
-            });
-        });
-
-        describe("ERC1155", () => {
-            /**
-             * Set up a withdrawal test by depositing some ERC1155s into a bundle
-             */
-            const deposit = async (token: MockERC1155, vault: AssetVault, user: Signer, amount: BigNumber) => {
-                const tokenId = await mintERC1155(token, user, amount);
-                await token.safeTransferFrom(await user.getAddress(), vault.address, tokenId, amount, "0x");
-                return tokenId;
-            };
-
-            it("should withdraw single deposit from a bundle", async () => {
-                const { vault, mockERC1155, user } = await loadFixture(fixture);
-                const amount = BigNumber.from("1");
-                const tokenId = await deposit(mockERC1155, vault, user, amount);
-
-                await vault.enableWithdraw();
-                await expect(vault.connect(user).withdrawERC1155(mockERC1155.address, tokenId, await user.getAddress()))
-                    .to.emit(vault, "WithdrawERC1155")
-                    .withArgs(await user.getAddress(), mockERC1155.address, await user.getAddress(), tokenId, amount)
-                    .to.emit(mockERC1155, "TransferSingle")
-                    .withArgs(vault.address, vault.address, await user.getAddress(), tokenId, amount);
-            });
-
-            it("should withdraw fungible deposit from a bundle", async () => {
-                const { vault, mockERC1155, user } = await loadFixture(fixture);
-                const amount = hre.ethers.utils.parseEther("100");
-                const tokenId = await deposit(mockERC1155, vault, user, amount);
-
-                await vault.enableWithdraw();
-                await expect(vault.connect(user).withdrawERC1155(mockERC1155.address, tokenId, await user.getAddress()))
-                    .to.emit(vault, "WithdrawERC1155")
-                    .withArgs(await user.getAddress(), mockERC1155.address, await user.getAddress(), tokenId, amount)
-                    .to.emit(mockERC1155, "TransferSingle")
-                    .withArgs(vault.address, vault.address, await user.getAddress(), tokenId, amount);
-            });
-
-            it("should fail to withdraw when withdraws disabled", async () => {
-                const { vault, mockERC1155, user } = await loadFixture(fixture);
-                const amount = hre.ethers.utils.parseEther("100");
-                const tokenId = await deposit(mockERC1155, vault, user, amount);
-
-                await expect(
-                    vault.connect(user).withdrawERC1155(mockERC1155.address, tokenId, await user.getAddress()),
-                ).to.be.revertedWith("AV_WithdrawsDisabled");
-            });
-
-            it("should throw when withdraw called by non-owner", async () => {
-                const { vault, mockERC1155, user, other } = await loadFixture(fixture);
-                const amount = BigNumber.from("1");
-                const tokenId = await deposit(mockERC1155, vault, user, amount);
-
-                await vault.enableWithdraw();
-                await expect(
-                    vault.connect(other).withdrawERC1155(mockERC1155.address, tokenId, await other.getAddress()),
-                ).to.be.revertedWith("OERC721_CallerNotOwner");
-            });
-        });
-
-        describe("ETH", () => {
-            const deposit = async (vault: AssetVault, user: Signer, amount: BigNumber) => {
-                await user.sendTransaction({
-                    to: vault.address,
-                    value: amount,
-                });
-            };
-
-            it("should withdraw single deposit from a bundle", async () => {
-                const { vault, user } = await loadFixture(fixture);
-                const amount = hre.ethers.utils.parseEther("123");
-                await deposit(vault, user, amount);
-                const startingBalance = await vault.provider.getBalance(await user.getAddress());
-
-                await vault.enableWithdraw();
-                await expect(vault.connect(user).withdrawETH(await user.getAddress()))
-                    .to.emit(vault, "WithdrawETH")
-                    .withArgs(await user.getAddress(), await user.getAddress(), amount);
-
-                const threshold = hre.ethers.utils.parseEther("0.01"); // for txn fee
-                const endingBalance = await vault.provider.getBalance(await user.getAddress());
-                expect(endingBalance.sub(startingBalance).gt(amount.sub(threshold))).to.be.true;
-            });
-
-            it("should fail to withdraw when withdraws disabled", async () => {
-                const { vault, user } = await loadFixture(fixture);
-                const amount = hre.ethers.utils.parseEther("123");
-                await deposit(vault, user, amount);
-
-                await expect(vault.connect(user).withdrawETH(await user.getAddress())).to.be.revertedWith(
-                    "AV_WithdrawsDisabled",
-                );
-            });
-
-            it("should throw when withdraw called by non-owner", async () => {
-                const { vault, user, other } = await loadFixture(fixture);
-                const amount = hre.ethers.utils.parseEther("9");
-                await deposit(vault, user, amount);
-
-                await expect(vault.connect(other).withdrawETH(await other.getAddress())).to.be.revertedWith(
-                    "OERC721_CallerNotOwner",
-                );
-            });
-        });
-
-        describe("Introspection", function () {
-            it("should return true for declaring support for eip165 interface contract", async () => {
-                const { nft } = await loadFixture(fixture);
-                // https://eips.ethereum.org/EIPS/eip-165#test-cases
-                expect(await nft.supportsInterface("0x01ffc9a7")).to.be.true;
-                expect(await nft.supportsInterface("0xfafafafa")).to.be.false;
-            });
         });
     });
 });

--- a/test/VaultDepositRouter.ts
+++ b/test/VaultDepositRouter.ts
@@ -204,7 +204,7 @@ describe("VaultDepositRouter", () => {
             expect(items[0].tokenAmount).to.eq(amount);
         });
 
-        it("should accept deposit from an ERC20 token and report inventory", async () => {
+        it("should accept deposit of an ERC20 token and report inventory", async () => {
             const { vault, mockERC20, user, router, reporter } = ctx;
             const amount = hre.ethers.utils.parseUnits("50", 18);
 
@@ -225,7 +225,7 @@ describe("VaultDepositRouter", () => {
             expect(items[0].tokenAmount).to.eq(amount);
         });
 
-        it("should accept deposit from an ERC721 token and report inventory", async () => {
+        it("should accept deposit of an ERC721 token and report inventory", async () => {
             const { vault, mockERC721, user, router, reporter } = ctx;
 
             const tokenId = await mintERC721(mockERC721, user);
@@ -247,7 +247,7 @@ describe("VaultDepositRouter", () => {
             expect(items[0].tokenId).to.eq(tokenId);
         });
 
-        it("should accept deposit from an ERC1155 token and report inventory", async () => {
+        it("should accept deposit of an ERC1155 token and report inventory", async () => {
             const { vault, mockERC1155, user, router, reporter } = ctx;
             const amount = hre.ethers.utils.parseUnits("50", 18);
 
@@ -269,7 +269,7 @@ describe("VaultDepositRouter", () => {
             expect(items[0].tokenAmount).to.eq(amount);
         });
 
-        it("should accept deposit from a CryptoPunk and report inventory", async () => {
+        it("should accept deposit of a CryptoPunk and report inventory", async () => {
             const { vault, punks, user, router, reporter } = ctx;
 
             const tokenId = 8888;
@@ -292,7 +292,7 @@ describe("VaultDepositRouter", () => {
             expect(items[0].tokenId).to.eq(tokenId);
         });
 
-        it("should accept deposit from an ERC20 token batch and report inventory", async () => {
+        it("should accept deposit of an ERC20 token batch and report inventory", async () => {
             const { vault, mockERC20, user, router, reporter } = ctx;
             const amount = hre.ethers.utils.parseUnits("50", 18);
 
@@ -333,7 +333,7 @@ describe("VaultDepositRouter", () => {
             expect(items[1].tokenAmount).to.eq(amount.div(2));
         });
 
-        it("should accept deposit from an ERC721 token batch and report inventory", async () => {
+        it("should accept deposit of an ERC721 token batch and report inventory", async () => {
             const { vault, mockERC721, user, router, reporter } = ctx;
 
             const otherMockERC721 = <MockERC721>await deploy("MockERC721", user, ["Mock ERC721", "MOCK"]);
@@ -380,7 +380,7 @@ describe("VaultDepositRouter", () => {
             expect(items[2].tokenId).to.eq(tokenId3);
         });
 
-        it("should accept deposit from an ERC1155 token batch and report inventory", async () => {
+        it("should accept deposit of an ERC1155 token batch and report inventory", async () => {
             const { vault, mockERC1155, user, router, reporter } = ctx;
             const amount = hre.ethers.utils.parseUnits("50", 18);
 
@@ -450,7 +450,7 @@ describe("VaultDepositRouter", () => {
             expect(items[2].tokenAmount).to.eq(amount);
         });
 
-        it("should accept deposit from a CryptoPunk batch and report inventory", async () => {
+        it("should accept deposit of a CryptoPunk batch and report inventory", async () => {
             const { vault, punks, user, router, reporter } = ctx;
 
             const tokenId = 8888;

--- a/test/VaultDepositRouter.ts
+++ b/test/VaultDepositRouter.ts
@@ -415,9 +415,9 @@ describe("VaultDepositRouter", () => {
             await expect(
                 router.connect(user).depositERC1155Batch(
                     vault.address,
-                    [mockERC1155.address, otherMockERC1155.address, mockERC1155.address],
+                    [mockERC1155.address, otherMockERC1155.address],
                     [tokenId, tokenId2, tokenId3],
-                    [amount, amount]
+                    [amount, amount, amount]
                 )
             ).to.be.revertedWith("VDR_BatchLengthMismatch");
 

--- a/test/VaultDepositRouter.ts
+++ b/test/VaultDepositRouter.ts
@@ -129,8 +129,19 @@ describe("VaultDepositRouter", () => {
     });
 
     describe("Deposits", () => {
+        let ctx: TestContext;
+
+        beforeEach(async () => {
+            ctx = await loadFixture(fixture);
+
+            // Approve the router to make reports for the user
+            const { reporter, user, router, vault } = ctx;
+
+            await reporter.connect(user).setApproval(vault.address, router.address);
+        });
+
         it("should not accept a deposit for the zero address", async () => {
-            const { mockERC20, user, router } = await loadFixture(fixture);
+            const { mockERC20, user, router } = ctx;
             const amount = hre.ethers.utils.parseUnits("50", 18);
 
             await mint(mockERC20, user, amount);
@@ -140,11 +151,11 @@ describe("VaultDepositRouter", () => {
             // Reporter address not a valid vault
             await expect(
                 router.connect(user).depositERC20(ZERO_ADDRESS, mockERC20.address, amount)
-            ).to.be.revertedWith("VDR_ZeroAddress");
+            ).to.be.revertedWith("VOC_ZeroAddress");
         });
 
         it("should not accept a deposit for a vault that does not exist", async () => {
-            const { mockERC20, user, router, reporter } = await loadFixture(fixture);
+            const { mockERC20, user, router, reporter } = ctx;
             const amount = hre.ethers.utils.parseUnits("50", 18);
 
             await mint(mockERC20, user, amount);
@@ -154,11 +165,11 @@ describe("VaultDepositRouter", () => {
             // Reporter address not a valid vault
             await expect(
                 router.connect(user).depositERC20(reporter.address, mockERC20.address, amount)
-            ).to.be.revertedWith("VDR_InvalidVault");
+            ).to.be.revertedWith("VOC_InvalidVault");
         });
 
         it("should not accept a deposit if the user is not the owner of a vault", async () => {
-            const { vault, mockERC20, user, other, router } = await loadFixture(fixture);
+            const { vault, mockERC20, user, other, router } = ctx;
             const amount = hre.ethers.utils.parseUnits("50", 18);
 
             await mint(mockERC20, user, amount);
@@ -168,11 +179,11 @@ describe("VaultDepositRouter", () => {
             // Reporter address not a valid vault
             await expect(
                 router.connect(other).depositERC20(vault.address, mockERC20.address, amount)
-            ).to.be.revertedWith("VDR_NotOwnerOrApproved");
+            ).to.be.revertedWith("VOC_NotOwnerOrApproved");
         });
 
         it("should accept a deposit if the depositor has an approval from the owner", async () => {
-            const { nft, vault, mockERC20, user, other, router, reporter } = await loadFixture(fixture);
+            const { nft, vault, mockERC20, user, other, router, reporter } = ctx;
             const amount = hre.ethers.utils.parseUnits("50", 18);
 
             await mint(mockERC20, other, amount);
@@ -194,7 +205,7 @@ describe("VaultDepositRouter", () => {
         });
 
         it("should accept deposit from an ERC20 token and report inventory", async () => {
-            const { vault, mockERC20, user, router, reporter } = await loadFixture(fixture);
+            const { vault, mockERC20, user, router, reporter } = ctx;
             const amount = hre.ethers.utils.parseUnits("50", 18);
 
             await mint(mockERC20, user, amount);
@@ -215,7 +226,7 @@ describe("VaultDepositRouter", () => {
         });
 
         it("should accept deposit from an ERC721 token and report inventory", async () => {
-            const { vault, mockERC721, user, router, reporter } = await loadFixture(fixture);
+            const { vault, mockERC721, user, router, reporter } = ctx;
 
             const tokenId = await mintERC721(mockERC721, user);
 
@@ -237,7 +248,7 @@ describe("VaultDepositRouter", () => {
         });
 
         it("should accept deposit from an ERC1155 token and report inventory", async () => {
-            const { vault, mockERC1155, user, router, reporter } = await loadFixture(fixture);
+            const { vault, mockERC1155, user, router, reporter } = ctx;
             const amount = hre.ethers.utils.parseUnits("50", 18);
 
             const tokenId = await mintERC1155(mockERC1155, user, amount);
@@ -259,7 +270,7 @@ describe("VaultDepositRouter", () => {
         });
 
         it("should accept deposit from a CryptoPunk and report inventory", async () => {
-            const { vault, punks, user, router, reporter } = await loadFixture(fixture);
+            const { vault, punks, user, router, reporter } = ctx;
 
             const tokenId = 8888;
             await punks.setInitialOwner(user.address, tokenId);
@@ -282,7 +293,7 @@ describe("VaultDepositRouter", () => {
         });
 
         it("should accept deposit from an ERC20 token batch and report inventory", async () => {
-            const { vault, mockERC20, user, router, reporter } = await loadFixture(fixture);
+            const { vault, mockERC20, user, router, reporter } = ctx;
             const amount = hre.ethers.utils.parseUnits("50", 18);
 
             const otherMockERC20 = <MockERC20>await deploy("MockERC20", user, ["Mock ERC20", "MOCK"]);
@@ -323,7 +334,7 @@ describe("VaultDepositRouter", () => {
         });
 
         it("should accept deposit from an ERC721 token batch and report inventory", async () => {
-            const { vault, mockERC721, user, router, reporter } = await loadFixture(fixture);
+            const { vault, mockERC721, user, router, reporter } = ctx;
 
             const otherMockERC721 = <MockERC721>await deploy("MockERC721", user, ["Mock ERC721", "MOCK"]);
 
@@ -370,7 +381,7 @@ describe("VaultDepositRouter", () => {
         });
 
         it("should accept deposit from an ERC1155 token batch and report inventory", async () => {
-            const { vault, mockERC1155, user, router, reporter } = await loadFixture(fixture);
+            const { vault, mockERC1155, user, router, reporter } = ctx;
             const amount = hre.ethers.utils.parseUnits("50", 18);
 
             const otherMockERC1155 = <MockERC1155>await deploy("MockERC1155", user, []);
@@ -440,7 +451,7 @@ describe("VaultDepositRouter", () => {
         });
 
         it("should accept deposit from a CryptoPunk batch and report inventory", async () => {
-            const { vault, punks, user, router, reporter } = await loadFixture(fixture);
+            const { vault, punks, user, router, reporter } = ctx;
 
             const tokenId = 8888;
             const tokenId2 = 5555;

--- a/test/VaultInventoryReporter.ts
+++ b/test/VaultInventoryReporter.ts
@@ -21,6 +21,7 @@ import { mintToAddress as mintERC721 } from "./utils/erc721";
 import { mintToAddress as mintERC1155 } from "./utils/erc1155";
 import { deploy } from "./utils/contracts";
 import { createInventoryPermitSignature, InventoryPermitData } from "./utils/eip712";
+import { report } from "process";
 
 type Signer = SignerWithAddress;
 
@@ -62,6 +63,14 @@ interface TestContext {
 }
 
 describe("VaultInventoryReporter", () => {
+    let defaultItems: Item[];
+    let ctx: TestContext;
+    let amount20: BigNumberish;
+    let id721: BigNumberish;
+    let id1155: BigNumberish;
+    let amount1155: BigNumberish;
+    let idPunk: BigNumberish;
+
     /**
      * Creates a vault instance using the vault factory
      */
@@ -127,33 +136,54 @@ describe("VaultInventoryReporter", () => {
         };
     };
 
+    beforeEach(async () => {
+        // before - mint some NFTs and transfer to vault
+        ctx = await loadFixture(fixture);
+
+        const { vault, mockERC20, mockERC721, mockERC1155, punks } = ctx;
+
+        amount20 = ethers.utils.parseEther("100");
+        await mockERC20.mint(vault.address, amount20);
+
+        id721 = await mintERC721(mockERC721, vault.address);
+
+        amount1155 = ethers.BigNumber.from(10);
+        id1155 = await mintERC1155(mockERC1155, vault.address, amount1155 as BigNumber);
+
+        idPunk = 8888;
+        await punks.setInitialOwner(vault.address, idPunk);
+        await punks.allInitialOwnersAssigned();
+
+        defaultItems = [
+            {
+                itemType: ERC_20_ITEM_TYPE,
+                tokenAddress: mockERC20.address,
+                tokenId: 0,
+                tokenAmount: amount20
+            },
+            {
+                itemType: ERC_721_ITEM_TYPE,
+                tokenAddress: mockERC721.address,
+                tokenId: id721,
+                tokenAmount: 0
+            },
+            {
+                itemType: ERC_1155_ITEM_TYPE,
+                tokenAddress: mockERC1155.address,
+                tokenId: id1155,
+                tokenAmount: amount1155
+            },
+            {
+                itemType: PUNKS_ITEM_TYPE,
+                tokenAddress: punks.address,
+                tokenId: idPunk,
+                tokenAmount: 0
+            }
+        ];
+    });
+
     describe("Inventory Operations", () => {
         describe("add", () => {
-            let ctx: TestContext;
-            let amount20: BigNumberish;
-            let id721: BigNumberish;
-            let id1155: BigNumberish;
-            let amount1155: BigNumberish;
-            let idPunk: BigNumberish;
-
-            beforeEach(async () => {
-                // before - mint some NFTs and transfer to vault
-                ctx = await loadFixture(fixture);
-
-                const { vault, mockERC20, mockERC721, mockERC1155, punks } = ctx;
-
-                amount20 = ethers.utils.parseEther("100");
-                await mockERC20.mint(vault.address, amount20);
-
-                id721 = await mintERC721(mockERC721, vault.address);
-
-                amount1155 = ethers.BigNumber.from(10);
-                id1155 = await mintERC1155(mockERC1155, vault.address, amount1155 as BigNumber);
-
-                idPunk = 8888;
-                await punks.setInitialOwner(vault.address, idPunk);
-                await punks.allInitialOwnersAssigned();
-            });
 
             it("should revert if attempting to add zero items", async () => {
                 const { reporter, user, vault } = ctx;
@@ -278,34 +308,9 @@ describe("VaultInventoryReporter", () => {
             });
 
             it("should allow the vault owner to add items to inventory", async () => {
-                const { reporter, user, vault, punks, mockERC1155, mockERC20, mockERC721 } = ctx;
+                const { reporter, user, vault } = ctx;
 
-                const items: Item[] = [
-                    {
-                        itemType: ERC_20_ITEM_TYPE,
-                        tokenAddress: mockERC20.address,
-                        tokenId: 0,
-                        tokenAmount: amount20
-                    },
-                    {
-                        itemType: ERC_721_ITEM_TYPE,
-                        tokenAddress: mockERC721.address,
-                        tokenId: id721,
-                        tokenAmount: 0
-                    },
-                    {
-                        itemType: ERC_1155_ITEM_TYPE,
-                        tokenAddress: mockERC1155.address,
-                        tokenId: id1155,
-                        tokenAmount: amount1155
-                    },
-                    {
-                        itemType: PUNKS_ITEM_TYPE,
-                        tokenAddress: punks.address,
-                        tokenId: idPunk,
-                        tokenAmount: 0
-                    }
-                ];
+                const items = defaultItems;
 
                 await expect(
                     reporter.connect(user).add(vault.address, items)
@@ -320,36 +325,11 @@ describe("VaultInventoryReporter", () => {
             });
 
             it("should allow an approved address to add items to inventory", async () => {
-                const { reporter, user, other, vault, punks, mockERC1155, mockERC20, mockERC721 } = ctx;
+                const { reporter, user, other, vault } = ctx;
 
                 await reporter.connect(user).setApproval(vault.address, other.address);
 
-                const items: Item[] = [
-                    {
-                        itemType: ERC_20_ITEM_TYPE,
-                        tokenAddress: mockERC20.address,
-                        tokenId: 0,
-                        tokenAmount: amount20
-                    },
-                    {
-                        itemType: ERC_721_ITEM_TYPE,
-                        tokenAddress: mockERC721.address,
-                        tokenId: id721,
-                        tokenAmount: 0
-                    },
-                    {
-                        itemType: ERC_1155_ITEM_TYPE,
-                        tokenAddress: mockERC1155.address,
-                        tokenId: id1155,
-                        tokenAmount: amount1155
-                    },
-                    {
-                        itemType: PUNKS_ITEM_TYPE,
-                        tokenAddress: punks.address,
-                        tokenId: idPunk,
-                        tokenAmount: 0
-                    }
-                ];
+                const items = defaultItems;
 
                 await expect(
                     reporter.connect(other).add(vault.address, items)
@@ -361,12 +341,12 @@ describe("VaultInventoryReporter", () => {
                     .withArgs(vault.address, other.address, hashItem(items[2]))
                     .to.emit(reporter, "Add")
                     .withArgs(vault.address, other.address, hashItem(items[3]));
+
+                expect((await reporter.keys(vault.address)).length).to.eq(4);
             });
 
-            it("should not allow an address to add items to inventory with an invalid permit signature");
-            it("should not allow an address to add items to inventory with an expired permit signature");
-            it("should allow an address to add items to inventory with a permit signature from the owner", async () => {
-                const { reporter, user, other, vault, punks, mockERC1155, mockERC20, mockERC721 } = ctx;
+            it("should not allow an address to add items to inventory with an invalid permit signature", async () => {
+                const { reporter, user, other, vault } = ctx;
 
                 const deadline = maxDeadline;
 
@@ -374,7 +354,7 @@ describe("VaultInventoryReporter", () => {
                     owner: user.address,
                     target: other.address,
                     vault: vault.address,
-                    nonce: 1,
+                    nonce: 1000, // use invalid nonce
                     deadline
                 };
 
@@ -385,32 +365,63 @@ describe("VaultInventoryReporter", () => {
                     user
                 );
 
-                const items: Item[] = [
-                    {
-                        itemType: ERC_20_ITEM_TYPE,
-                        tokenAddress: mockERC20.address,
-                        tokenId: 0,
-                        tokenAmount: amount20
-                    },
-                    {
-                        itemType: ERC_721_ITEM_TYPE,
-                        tokenAddress: mockERC721.address,
-                        tokenId: id721,
-                        tokenAmount: 0
-                    },
-                    {
-                        itemType: ERC_1155_ITEM_TYPE,
-                        tokenAddress: mockERC1155.address,
-                        tokenId: id1155,
-                        tokenAmount: amount1155
-                    },
-                    {
-                        itemType: PUNKS_ITEM_TYPE,
-                        tokenAddress: punks.address,
-                        tokenId: idPunk,
-                        tokenAmount: 0
-                    }
-                ];
+                const items = defaultItems;
+
+                await expect(
+                    reporter.connect(other).addWithPermit(vault.address, items, deadline, sig.v, sig.r, sig.s)
+                ).to.be.revertedWith("VIR_InvalidPermitSignature");
+            });
+
+            it("should not allow an address to add items to inventory with an expired permit signature", async () => {
+                const { reporter, user, other, vault } = ctx;
+
+                // Make deadline in the past
+                const lastBlock = await hre.ethers.provider.getBlock("latest");
+                const deadline = lastBlock.timestamp - 1000;
+
+                const permitData: InventoryPermitData = {
+                    owner: user.address,
+                    target: other.address,
+                    vault: vault.address,
+                    nonce: 0,
+                    deadline
+                };
+
+                const sig = await createInventoryPermitSignature(
+                    reporter.address,
+                    NAME,
+                    permitData,
+                    user
+                );
+
+                const items = defaultItems;
+
+                await expect(
+                    reporter.connect(other).addWithPermit(vault.address, items, deadline, sig.v, sig.r, sig.s)
+                ).to.be.revertedWith("VIR_PermitDeadlineExpired");
+            });
+
+            it("should allow an address to add items to inventory with a permit signature from the owner", async () => {
+                const { reporter, user, other, vault } = ctx;
+
+                const deadline = maxDeadline;
+
+                const permitData: InventoryPermitData = {
+                    owner: user.address,
+                    target: other.address,
+                    vault: vault.address,
+                    nonce: 0,
+                    deadline
+                };
+
+                const sig = await createInventoryPermitSignature(
+                    reporter.address,
+                    NAME,
+                    permitData,
+                    user
+                );
+
+                const items = defaultItems;
 
                 await expect(
                     reporter.connect(other).addWithPermit(vault.address, items, deadline, sig.v, sig.r, sig.s)
@@ -426,51 +437,509 @@ describe("VaultInventoryReporter", () => {
         });
 
         describe("remove", () => {
-            // before - mint some NFTs and register some inventory
+            beforeEach(async () => {
+                // before - mint some NFTs and register some inventory
+                const { reporter, user, vault } = ctx;
 
-            it("should revert if attempting to remove zero items");
-            it("should revert if attempting to remove more items than the maximum");
-            it("should revert if the caller is not the vault's owner or approved");
-            it("should allow the vault owner to remove items from inventory");
-            it("should allow an approved address to remove items from inventory");
-            it("should not revert if a specified item is not registered in inventory");
-            it("should not allow an address to remove items from inventory with an invalid permit signature");
-            it("should not allow an address to remove items from inventory with an expired permit signature");
-            it("should allow an address to remove items from inventory with a permit signature from the owner");
+                await reporter.connect(user).add(vault.address, defaultItems);
+            });
+
+            it("should revert if attempting to remove zero items", async () => {
+                const { reporter, user, vault } = ctx;
+
+                await expect(
+                    reporter.connect(user).remove(vault.address, [])
+                ).to.be.revertedWith("VIR_NoItems");
+            });
+
+            it("should revert if attempting to remove more items than the maximum", async () => {
+                const { reporter, user, vault, mockERC20 } = ctx;
+
+                const item: Item = {
+                    itemType: ERC_20_ITEM_TYPE,
+                    tokenAddress: mockERC20.address,
+                    tokenId: 0,
+                    tokenAmount: amount20
+                };
+
+                // Create a vault of 51 items.
+                const items = (Array(51) as Item[]).fill(item, 0, 51);
+
+                await expect(
+                    reporter.connect(user).remove(vault.address, items)
+                ).to.be.revertedWith("VIR_TooManyItems");
+            });
+
+            it("should revert if the caller is not the vault's owner or approved", async () => {
+                const { reporter, other, vault } = ctx;
+                const items = defaultItems;
+
+                await expect(
+                    reporter.connect(other).remove(vault.address, items)
+                ).to.be.revertedWith("VIR_NotApproved");
+            });
+
+            it("should allow the vault owner to remove items from inventory", async () => {
+                const { reporter, user, vault } = ctx;
+
+                await expect(
+                    reporter.connect(user).remove(vault.address, defaultItems)
+                ).to.emit(reporter, "Remove")
+                    .withArgs(vault.address, user.address, hashItem(defaultItems[0]))
+                    .to.emit(reporter, "Remove")
+                    .withArgs(vault.address, user.address, hashItem(defaultItems[1]))
+                    .to.emit(reporter, "Remove")
+                    .withArgs(vault.address, user.address, hashItem(defaultItems[2]))
+                    .to.emit(reporter, "Remove")
+                    .withArgs(vault.address, user.address, hashItem(defaultItems[3]));
+            });
+
+            it("should allow an approved address to remove items from inventory", async () => {
+                const { reporter, user, other, vault } = ctx;
+
+                await reporter.connect(user).setApproval(vault.address, other.address);
+
+                await expect(
+                    reporter.connect(other).remove(vault.address, defaultItems)
+                ).to.emit(reporter, "Remove")
+                    .withArgs(vault.address, other.address, hashItem(defaultItems[0]))
+                    .to.emit(reporter, "Remove")
+                    .withArgs(vault.address, other.address, hashItem(defaultItems[1]))
+                    .to.emit(reporter, "Remove")
+                    .withArgs(vault.address, other.address, hashItem(defaultItems[2]))
+                    .to.emit(reporter, "Remove")
+                    .withArgs(vault.address, other.address, hashItem(defaultItems[3]));
+
+                expect((await reporter.keys(vault.address)).length).to.eq(0);
+            });
+
+            it("should not revert if a specified item is not registered in inventory", async () => {
+                const { reporter, user, vault, mockERC721 } = ctx;
+
+                // Add an item not previously registered
+                const items = [
+                    ...defaultItems,
+                    {
+                        itemType: ERC_721_ITEM_TYPE,
+                        tokenAddress: mockERC721.address,
+                        tokenId: BigNumber.from(id721).mul(2), // Different ID
+                        tokenAmount: 0
+                    }
+                ]
+
+
+                const tx = await reporter.connect(user).remove(vault.address, items);
+                const receipt = await tx.wait();
+
+                // Make sure only 4 events, although there are 5 items
+                expect(receipt?.events?.length).to.eq(items.length - 1);
+            });
+
+            it("should not allow an address to remove items from inventory with an invalid permit signature", async () => {
+                const { reporter, user, other, vault } = ctx;
+
+                const deadline = maxDeadline;
+
+                const permitData: InventoryPermitData = {
+                    owner: user.address,
+                    target: other.address,
+                    vault: vault.address,
+                    nonce: 1000, // use invalid nonce
+                    deadline
+                };
+
+                const sig = await createInventoryPermitSignature(
+                    reporter.address,
+                    NAME,
+                    permitData,
+                    user
+                );
+
+                await expect(
+                    reporter.connect(other).removeWithPermit(vault.address, defaultItems, deadline, sig.v, sig.r, sig.s)
+                ).to.be.revertedWith("VIR_InvalidPermitSignature");
+            });
+
+            it("should not allow an address to remove items from inventory with an expired permit signature", async () => {
+                const { reporter, user, other, vault } = ctx;
+
+                // Make deadline in the past
+                const lastBlock = await hre.ethers.provider.getBlock("latest");
+                const deadline = lastBlock.timestamp - 1000;
+
+                const permitData: InventoryPermitData = {
+                    owner: user.address,
+                    target: other.address,
+                    vault: vault.address,
+                    nonce: 0,
+                    deadline
+                };
+
+                const sig = await createInventoryPermitSignature(
+                    reporter.address,
+                    NAME,
+                    permitData,
+                    user
+                );
+
+                const items = defaultItems;
+
+                await expect(
+                    reporter.connect(other).removeWithPermit(vault.address, items, deadline, sig.v, sig.r, sig.s)
+                ).to.be.revertedWith("VIR_PermitDeadlineExpired");
+            });
+
+            it("should allow an address to remove items from inventory with a permit signature from the owner", async () => {
+                const { reporter, user, other, vault } = ctx;
+
+                const deadline = maxDeadline;
+
+                const permitData: InventoryPermitData = {
+                    owner: user.address,
+                    target: other.address,
+                    vault: vault.address,
+                    nonce: 0,
+                    deadline
+                };
+
+                const sig = await createInventoryPermitSignature(
+                    reporter.address,
+                    NAME,
+                    permitData,
+                    user
+                );
+
+                const items = defaultItems;
+
+                await expect(
+                    reporter.connect(other).removeWithPermit(vault.address, items, deadline, sig.v, sig.r, sig.s)
+                ).to.emit(reporter, "Remove")
+                    .withArgs(vault.address, other.address, hashItem(items[0]))
+                    .to.emit(reporter, "Remove")
+                    .withArgs(vault.address, other.address, hashItem(items[1]))
+                    .to.emit(reporter, "Remove")
+                    .withArgs(vault.address, other.address, hashItem(items[2]))
+                    .to.emit(reporter, "Remove")
+                    .withArgs(vault.address, other.address, hashItem(items[3]));
+            });
         });
 
         describe("clear", () => {
             // before - mint some NFTs and register some inventory
+            beforeEach(async () => {
+                // before - mint some NFTs and register some inventory
+                const { reporter, user, vault } = ctx;
 
-            it("should revert if the vault's registered inventory is larger than the maximum items per update");
-            it("should revert if the caller is not the vault's owner or approved");
-            it("should allow the vault owner to clear inventory");
-            it("should allow an approved address to clear inventory");
-            it("should not allow an address to clear inventory with an invalid permit signature");
-            it("should not allow an address to clear inventory with an expired permit signature");
-            it("should allow an address to clear inventory with a permit signature from the owner");
+                await reporter.connect(user).add(vault.address, defaultItems);
+            });
+
+            it("should revert if the vault's registered inventory is larger than the maximum items per update", async () => {
+                const { reporter, user, mockERC721, vault } = ctx;
+                const numToAdd = (await reporter.MAX_ITEMS_PER_REGISTRATION()).sub(1).toNumber();
+
+                const items: Item[] = [];
+
+                // Mint 49 more NFTs and add to inventory
+                for (let i = 0; i < numToAdd - 1; i++) {
+                    items.push({
+                        itemType: ERC_721_ITEM_TYPE,
+                        tokenAddress: mockERC721.address,
+                        tokenId: await mintERC721(mockERC721, vault.address),
+                        tokenAmount: 0
+                    });
+                }
+
+                await reporter.connect(user).add(vault.address, items);
+
+                // Try to clear
+                await expect(
+                    reporter.connect(user).clear(vault.address)
+                ).to.be.revertedWith("VIR_TooManyItems");
+            });
+
+            it("should revert if the caller is not the vault's owner or approved", async () => {
+                const { reporter, other, vault } = ctx;
+
+                await expect(
+                    reporter.connect(other).clear(vault.address)
+                ).to.be.revertedWith("VIR_NotApproved");
+            });
+
+            it("should allow the vault owner to clear inventory", async () => {
+                const { reporter, user, vault } = ctx;
+
+                await expect(
+                    reporter.connect(user).clear(vault.address)
+                ).to.emit(reporter, "Clear")
+                    .withArgs(vault.address, user.address);
+
+                expect((await reporter.keys(vault.address)).length).to.eq(0);
+            });
+
+            it("should allow an approved address to clear inventory", async () => {
+                const { reporter, user, other, vault } = ctx;
+
+                await reporter.connect(user).setApproval(vault.address, other.address);
+
+                await expect(
+                    reporter.connect(other).clear(vault.address)
+                ).to.emit(reporter, "Clear")
+                    .withArgs(vault.address, other.address);
+            });
+
+            it("should not allow an address to clear inventory with an invalid permit signature", async () => {
+                const { reporter, user, other, vault } = ctx;
+
+                const deadline = maxDeadline;
+
+                const permitData: InventoryPermitData = {
+                    owner: user.address,
+                    target: other.address,
+                    vault: vault.address,
+                    nonce: 1000, // use invalid nonce
+                    deadline
+                };
+
+                const sig = await createInventoryPermitSignature(
+                    reporter.address,
+                    NAME,
+                    permitData,
+                    user
+                );
+
+                await expect(
+                    reporter.connect(other).clearWithPermit(vault.address, deadline, sig.v, sig.r, sig.s)
+                ).to.be.revertedWith("VIR_InvalidPermitSignature");
+            });
+
+            it("should not allow an address to clear inventory with an expired permit signature", async () => {
+                const { reporter, user, other, vault } = ctx;
+
+                // Make deadline in the past
+                const lastBlock = await hre.ethers.provider.getBlock("latest");
+                const deadline = lastBlock.timestamp - 1000;
+
+                const permitData: InventoryPermitData = {
+                    owner: user.address,
+                    target: other.address,
+                    vault: vault.address,
+                    nonce: 0,
+                    deadline
+                };
+
+                const sig = await createInventoryPermitSignature(
+                    reporter.address,
+                    NAME,
+                    permitData,
+                    user
+                );
+
+                await expect(
+                    reporter.connect(other).clearWithPermit(vault.address, deadline, sig.v, sig.r, sig.s)
+                ).to.be.revertedWith("VIR_PermitDeadlineExpired");
+            });
+
+            it("should allow an address to clear inventory with a permit signature from the owner", async () => {
+                const { reporter, user, other, vault } = ctx;
+
+                const deadline = maxDeadline;
+
+                const permitData: InventoryPermitData = {
+                    owner: user.address,
+                    target: other.address,
+                    vault: vault.address,
+                    nonce: 0,
+                    deadline
+                };
+
+                const sig = await createInventoryPermitSignature(
+                    reporter.address,
+                    NAME,
+                    permitData,
+                    user
+                );
+
+                await expect(
+                    reporter.connect(other).clearWithPermit(vault.address, deadline, sig.v, sig.r, sig.s)
+                ).to.emit(reporter, "Clear")
+                    .withArgs(vault.address, other.address);
+            });
         });
     });
 
     describe("Verification", () => {
-        // Before - mint some NFTs and register some inventory
+        beforeEach(async () => {
+            // before - mint some NFTs and register some inventory
+            const { reporter, user, vault } = ctx;
 
-        it("should verify all items in a vault's inventory are currently held");
-        it("should return false if all items in a vault's inventory are not owned by the vault");
-        it("should verify whether a specific item in a vault's inventory is currently held");
-        it("should revert if a specific item submitted for verification is not in the registered inventory");
-        it("should return false if a specific item in a vault's inventory is not owned by the vault");
+            await reporter.connect(user).add(vault.address, defaultItems);
+        });
+
+        it("should verify all items in a vault's inventory are currently held", async () => {
+            const { reporter, vault } = ctx;
+
+            // Make sure verification succeeds
+            expect(await reporter.verify(vault.address)).to.be.true;
+        });
+
+        it("should return false if all items in a vault's inventory are not owned by the vault", async () => {
+            const { reporter, user, mockERC721, vault } = ctx;
+
+            // Make sure verification succeeds
+            expect(await reporter.verify(vault.address)).to.be.true;
+
+            // Move item out of vault
+            await vault.connect(user).enableWithdraw();
+            await vault.connect(user).withdrawERC721(mockERC721.address, id721, user.address);
+
+            // make sure verification fails
+            expect(await reporter.verify(vault.address)).to.be.false;
+        });
+
+        it("should verify whether a specific item in a vault's inventory is currently held", async () => {
+            const { reporter, vault } = ctx;
+
+            // Make sure verification succeeds
+            expect(await reporter.verifyItem(vault.address, defaultItems[0])).to.be.true;
+        });
+
+        it("should revert if a specific item submitted for verification is not in the registered inventory", async () => {
+            const { reporter, vault } = ctx;
+
+            const item: Item = {
+                ...defaultItems[1],
+                tokenId: BigNumber.from(id721).mul(2)
+            };
+
+            await expect(
+                reporter.verifyItem(vault.address, item)
+            ).to.be.revertedWith("VIR_NotInInventory")
+        });
+
+        it("should return false if a specific item in a vault's inventory is not owned by the vault", async () => {
+            const { reporter, user, mockERC721, vault } = ctx;
+
+            // Make sure verification succeeds
+            expect(await reporter.verifyItem(vault.address, defaultItems[1])).to.be.true;
+
+            // Move item out of vault
+            await vault.connect(user).enableWithdraw();
+            await vault.connect(user).withdrawERC721(mockERC721.address, id721, user.address);
+
+            // make sure verification fails
+            expect(await reporter.verifyItem(vault.address, defaultItems[1])).to.be.false;
+        });
     });
 
     describe("Enumeration", () => {
-        // Before - mint some NFTs and register some inventory
+        beforeEach(async () => {
+            // before - mint some NFTs and register some inventory
+            const { reporter, user, vault } = ctx;
 
-        it("should enumerate all items in a vault, without checking staleness");
-        it("should enumerate all items in a vault, checking for staleness");
-        it("should revert on enumerateOrFail if inventory is stale");
-        it("should report all item hashes for a vault's inventory");
-        it("should report a specific item hash for a vault's inventory");
-        it("should report a specific item for a vault's inventory");
+            await reporter.connect(user).add(vault.address, defaultItems);
+        });
+
+        it("should enumerate all items in a vault, without checking staleness", async () => {
+            const { reporter, vault, user, mockERC721 } = ctx;
+
+            let items = await reporter.enumerate(vault.address);
+
+            expect(items.length).to.eq(defaultItems.length);
+
+            for (let i = 0; i < items.length; i++) {
+                expect(items[i].itemType).to.eq(defaultItems[i].itemType);
+                expect(items[i].tokenAddress).to.eq(defaultItems[i].tokenAddress);
+                expect(items[i].tokenId).to.eq(defaultItems[i].tokenId);
+                expect(items[i].tokenAmount).to.eq(defaultItems[i].tokenAmount);
+            }
+
+            // Move item out of vault
+            await vault.connect(user).enableWithdraw();
+            await vault.connect(user).withdrawERC721(mockERC721.address, id721, user.address);
+
+            // Enumerate again, get same results
+            items = await reporter.enumerate(vault.address);
+
+            expect(items.length).to.eq(defaultItems.length);
+
+            for (let i = 0; i < items.length; i++) {
+                expect(items[i].itemType).to.eq(defaultItems[i].itemType);
+                expect(items[i].tokenAddress).to.eq(defaultItems[i].tokenAddress);
+                expect(items[i].tokenId).to.eq(defaultItems[i].tokenId);
+                expect(items[i].tokenAmount).to.eq(defaultItems[i].tokenAmount);
+            }
+        });
+
+        it("should revert on enumerateOrFail if inventory is stale", async () => {
+            const { reporter, vault, user, mockERC721 } = ctx;
+
+            const items = await reporter.enumerateOrFail(vault.address);
+
+            expect(items.length).to.eq(defaultItems.length);
+
+            for (let i = 0; i < items.length; i++) {
+                expect(items[i].itemType).to.eq(defaultItems[i].itemType);
+                expect(items[i].tokenAddress).to.eq(defaultItems[i].tokenAddress);
+                expect(items[i].tokenId).to.eq(defaultItems[i].tokenId);
+                expect(items[i].tokenAmount).to.eq(defaultItems[i].tokenAmount);
+            }
+
+            // Move item out of vault
+            await vault.connect(user).enableWithdraw();
+            await vault.connect(user).withdrawERC721(mockERC721.address, id721, user.address);
+
+            // Enumerate again, get same results
+            await expect(
+                reporter.enumerateOrFail(vault.address)
+            ).to.be.revertedWith("VIR_NotVerified");
+        });
+
+        it("should report all item hashes for a vault's inventory", async () => {
+            const { reporter, vault } = ctx;
+
+            const keys = await reporter.keys(vault.address);
+
+            expect(keys.length).to.eq(defaultItems.length);
+
+            for (let i = 0; i < keys.length; i++) {
+                expect(keys[i]).to.eq(hashItem(defaultItems[i]));
+            }
+        });
+
+        it("should report a specific item hash for a vault's inventory", async () => {
+            const { reporter, vault } = ctx;
+
+            const keys = await reporter.keys(vault.address);
+
+            for (let i = 0; i < keys.length; i++) {
+                const key = await reporter.keyAtIndex(vault.address, i);
+                expect(key).to.eq(hashItem(defaultItems[i]));
+            }
+        });
+
+        it("should report a specific item for a vault's inventory", async () => {
+            const { reporter, vault, user, mockERC721 } = ctx;
+
+            const keys = await reporter.keys(vault.address);
+
+            for (let i = 0; i < keys.length; i++) {
+                const item = await reporter.itemAtIndex(vault.address, i);
+
+                expect(item.itemType).to.eq(defaultItems[i].itemType);
+                expect(item.tokenAddress).to.eq(defaultItems[i].tokenAddress);
+                expect(item.tokenId).to.eq(defaultItems[i].tokenId);
+                expect(item.tokenAmount).to.eq(defaultItems[i].tokenAmount);
+            }
+
+            // Move item out of vault
+            await vault.connect(user).enableWithdraw();
+            await vault.connect(user).withdrawERC721(mockERC721.address, id721, user.address);
+
+            // Enumerate again, get same results
+            await expect(
+                reporter.enumerateOrFail(vault.address)
+            ).to.be.revertedWith("VIR_NotVerified");
+        });
     });
 
     describe("Permissions", () => {

--- a/test/VaultInventoryReporter.ts
+++ b/test/VaultInventoryReporter.ts
@@ -1,0 +1,420 @@
+import chai, { expect } from "chai";
+import hre, { ethers, waffle, upgrades } from "hardhat";
+import { solidity } from "ethereum-waffle";
+const { loadFixture } = waffle;
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { BigNumber, BigNumberish } from "ethers";
+
+chai.use(solidity);
+
+import {
+    AssetVault,
+    CallWhitelist,
+    VaultFactory,
+    MockERC20,
+    MockERC721,
+    MockERC1155,
+    CryptoPunksMarket,
+    VaultInventoryReporter
+} from "../typechain";
+import { ZERO_ADDRESS } from "./utils/erc20";
+import { mintToAddress as mintERC721 } from "./utils/erc721";
+import { mintToAddress as mintERC1155 } from "./utils/erc1155";
+import { deploy } from "./utils/contracts";
+
+type Signer = SignerWithAddress;
+
+const ERC_721_ITEM_TYPE = 0;
+const ERC_1155_ITEM_TYPE = 1;
+const ERC_20_ITEM_TYPE = 2;
+const PUNKS_ITEM_TYPE = 3;
+
+const hashItem = (item: Item) => {
+    const types = ["address", "uint256", "uint256"];
+    const values = [item.tokenAddress, item.tokenId, item.tokenAmount];
+
+    return ethers.utils.solidityKeccak256(types, values);
+}
+
+interface Item {
+    itemType: BigNumberish;
+    tokenAddress: string;
+    tokenId: BigNumberish;
+    tokenAmount: BigNumberish;
+}
+interface TestContext {
+    vault: AssetVault;
+    vaultTemplate: AssetVault;
+    nft: VaultFactory;
+    whitelist: CallWhitelist;
+    bundleId: BigNumberish;
+    mockERC20: MockERC20;
+    mockERC721: MockERC721;
+    mockERC1155: MockERC1155;
+    punks: CryptoPunksMarket;
+    reporter: VaultInventoryReporter;
+    user: Signer;
+    other: Signer;
+    signers: Signer[];
+}
+
+describe("VaultInventoryReporter", () => {
+    /**
+     * Creates a vault instance using the vault factory
+     */
+    const createVault = async (factory: VaultFactory, user: Signer): Promise<AssetVault> => {
+        const tx = await factory.connect(user).initializeBundle(await user.getAddress());
+        const receipt = await tx.wait();
+
+        let vault: AssetVault | undefined;
+        if (receipt && receipt.events) {
+            for (const event of receipt.events) {
+                if (event.args && event.args.vault) {
+                    vault = <AssetVault>await hre.ethers.getContractAt("AssetVault", event.args.vault);
+                }
+            }
+        } else {
+            throw new Error("Unable to create new vault");
+        }
+        if (!vault) {
+            throw new Error("Unable to create new vault");
+        }
+        return vault;
+    };
+
+    /**
+     * Sets up a test context, deploying new contracts and returning them for use in a test
+     */
+    const fixture = async (): Promise<TestContext> => {
+        const signers: Signer[] = await hre.ethers.getSigners();
+        const whitelist = <CallWhitelist>await deploy("CallWhitelist", signers[0], []);
+        const mockERC20 = <MockERC20>await deploy("MockERC20", signers[0], ["Mock ERC20", "MOCK"]);
+        const mockERC721 = <MockERC721>await deploy("MockERC721", signers[0], ["Mock ERC721", "MOCK"]);
+        const mockERC1155 = <MockERC1155>await deploy("MockERC1155", signers[0], []);
+
+        const vaultTemplate = <AssetVault>await deploy("AssetVault", signers[0], []);
+        const VaultFactoryFactory = await hre.ethers.getContractFactory("VaultFactory");
+        const factory = <VaultFactory>await upgrades.deployProxy(
+            VaultFactoryFactory,
+            [vaultTemplate.address, whitelist.address],
+            {
+                kind: "uups",
+            },
+        );
+        const vault = await createVault(factory, signers[0]);
+
+        const punks = <CryptoPunksMarket>await deploy("CryptoPunksMarket", signers[0], []);
+
+        const reporter = <VaultInventoryReporter>await deploy("VaultInventoryReporter", signers[0], []);
+
+        return {
+            nft: factory,
+            vault,
+            vaultTemplate,
+            whitelist,
+            bundleId: vault.address,
+            mockERC20,
+            mockERC721,
+            mockERC1155,
+            user: signers[0],
+            other: signers[1],
+            signers: signers.slice(2),
+            punks,
+            reporter
+        };
+    };
+
+    describe("Inventory Operations", () => {
+        describe("add", () => {
+            let ctx: TestContext;
+            let amount20: BigNumberish;
+            let id721: BigNumberish;
+            let id1155: BigNumberish;
+            let amount1155: BigNumberish;
+            let idPunk: BigNumberish;
+
+            beforeEach(async () => {
+                // before - mint some NFTs and transfer to vault
+                ctx = await loadFixture(fixture);
+
+                const { vault, mockERC20, mockERC721, mockERC1155, punks } = ctx;
+
+                amount20 = ethers.utils.parseEther("100");
+                await mockERC20.mint(vault.address, amount20);
+
+                id721 = await mintERC721(mockERC721, vault.address);
+
+                amount1155 = ethers.BigNumber.from(10);
+                id1155 = await mintERC1155(mockERC1155, vault.address, amount1155 as BigNumber);
+
+                idPunk = 8888;
+                await punks.setInitialOwner(vault.address, idPunk);
+                await punks.allInitialOwnersAssigned();
+            });
+
+            it("should revert if attempting to add zero items", async () => {
+                const { reporter, user, vault } = ctx;
+
+                await expect(
+                    reporter.connect(user).add(vault.address, [])
+                ).to.be.revertedWith("VIR_NoItems");
+            });
+
+            it("should revert if attempting to add more items than the maximum", async () => {
+                const { reporter, user, vault, mockERC20 } = ctx;
+
+                const item: Item = {
+                    itemType: ERC_20_ITEM_TYPE,
+                    tokenAddress: mockERC20.address,
+                    tokenId: 0,
+                    tokenAmount: amount20
+                };
+
+                // Create a vault of 51 items.
+                const items = (Array(51) as Item[]).fill(item, 0, 51);
+
+                await expect(
+                    reporter.connect(user).add(vault.address, items)
+                ).to.be.revertedWith("VIR_TooManyItems");
+            });
+
+            it("should revert if the caller is not the vault's owner or approved", async () => {
+                const { reporter, other, vault, mockERC20 } = ctx;
+
+                const item: Item = {
+                    itemType: ERC_20_ITEM_TYPE,
+                    tokenAddress: mockERC20.address,
+                    tokenId: 0,
+                    tokenAmount: amount20
+                };
+
+                const items = [item];
+
+                await expect(
+                    reporter.connect(other).add(vault.address, items)
+                ).to.be.revertedWith("VIR_NotApproved");
+            });
+
+            it("should revert if not enough ERC20 tokens are held by the vault", async () => {
+                const { reporter, user, vault, mockERC20 } = ctx;
+
+                const item: Item = {
+                    itemType: ERC_20_ITEM_TYPE,
+                    tokenAddress: mockERC20.address,
+                    tokenId: 0,
+                    tokenAmount: (amount20 as BigNumber).mul(2) // more than the vault owns
+                };
+
+                const items = [item];
+
+                await expect(
+                    reporter.connect(user).add(vault.address, items)
+                ).to.be.revertedWith("VIR_NotVerified");
+            });
+
+            it("should revert if the specified ERC721 is not held by the vault", async () => {
+                const { reporter, user, vault, mockERC721 } = ctx;
+
+                // Mint a different 721
+                const tokenId2 = await mintERC721(mockERC721, user.address);
+
+                const item: Item = {
+                    itemType: ERC_721_ITEM_TYPE,
+                    tokenAddress: mockERC721.address,
+                    tokenId: tokenId2, // Different tokenID than vault owns
+                    tokenAmount: 0
+                };
+
+                const items = [item];
+
+                await expect(
+                    reporter.connect(user).add(vault.address, items)
+                ).to.be.revertedWith("VIR_NotVerified");
+            });
+
+            it("should revert if not enough of the specified ERC1155 tokens are not held by the vault", async () => {
+                const { reporter, user, vault, mockERC1155 } = ctx;
+
+                const item: Item = {
+                    itemType: ERC_1155_ITEM_TYPE,
+                    tokenAddress: mockERC1155.address,
+                    tokenId: (id1155 as BigNumber).add(1), // Different tokenID than minted
+                    tokenAmount: amount1155
+                };
+
+                const items = [item];
+
+                await expect(
+                    reporter.connect(user).add(vault.address, items)
+                ).to.be.revertedWith("VIR_NotVerified");
+
+                // Try again after using right token ID, but changing amount
+                item.tokenId = id1155;
+                item.tokenAmount = (amount1155 as BigNumber).mul(2);
+
+                await expect(
+                    reporter.connect(user).add(vault.address, items)
+                ).to.be.revertedWith("VIR_NotVerified");
+            });
+
+            it("should revert if the specified punk is not held by the vault", async () => {
+                const { reporter, user, vault, punks } = ctx;
+
+                const item: Item = {
+                    itemType: PUNKS_ITEM_TYPE,
+                    tokenAddress: punks.address,
+                    tokenId: (idPunk as number) + 1, // Different tokenID than vault owns
+                    tokenAmount: 0
+                };
+
+                const items = [item];
+
+                await expect(
+                    reporter.connect(user).add(vault.address, items)
+                ).to.be.revertedWith("VIR_NotVerified");
+            });
+
+            it("should allow the vault owner to add items to inventory", async () => {
+                const { reporter, user, vault, punks, mockERC1155, mockERC20, mockERC721 } = ctx;
+
+                const items: Item[] = [
+                    {
+                        itemType: ERC_20_ITEM_TYPE,
+                        tokenAddress: mockERC20.address,
+                        tokenId: 0,
+                        tokenAmount: amount20
+                    },
+                    {
+                        itemType: ERC_721_ITEM_TYPE,
+                        tokenAddress: mockERC721.address,
+                        tokenId: id721,
+                        tokenAmount: 0
+                    },
+                    {
+                        itemType: ERC_1155_ITEM_TYPE,
+                        tokenAddress: mockERC1155.address,
+                        tokenId: id1155,
+                        tokenAmount: amount1155
+                    },
+                    {
+                        itemType: PUNKS_ITEM_TYPE,
+                        tokenAddress: punks.address,
+                        tokenId: idPunk,
+                        tokenAmount: 0
+                    }
+                ];
+
+                await expect(
+                    reporter.connect(user).add(vault.address, items)
+                ).to.emit(reporter, "Add")
+                    .withArgs(vault.address, user.address, hashItem(items[0]))
+                    .to.emit(reporter, "Add")
+                    .withArgs(vault.address, user.address, hashItem(items[1]))
+                    .to.emit(reporter, "Add")
+                    .withArgs(vault.address, user.address, hashItem(items[2]))
+                    .to.emit(reporter, "Add")
+                    .withArgs(vault.address, user.address, hashItem(items[3]));
+            });
+
+            it("should allow an approved address to add items to inventory", async () => {
+                const { reporter, user, other, vault, punks, mockERC1155, mockERC20, mockERC721 } = ctx;
+
+                await reporter.connect(user).setApproval(vault.address, other.address);
+
+                const items: Item[] = [
+                    {
+                        itemType: ERC_20_ITEM_TYPE,
+                        tokenAddress: mockERC20.address,
+                        tokenId: 0,
+                        tokenAmount: amount20
+                    },
+                    {
+                        itemType: ERC_721_ITEM_TYPE,
+                        tokenAddress: mockERC721.address,
+                        tokenId: id721,
+                        tokenAmount: 0
+                    },
+                    {
+                        itemType: ERC_1155_ITEM_TYPE,
+                        tokenAddress: mockERC1155.address,
+                        tokenId: id1155,
+                        tokenAmount: amount1155
+                    },
+                    {
+                        itemType: PUNKS_ITEM_TYPE,
+                        tokenAddress: punks.address,
+                        tokenId: idPunk,
+                        tokenAmount: 0
+                    }
+                ];
+
+                await expect(
+                    reporter.connect(other).add(vault.address, items)
+                ).to.emit(reporter, "Add")
+                    .withArgs(vault.address, other.address, hashItem(items[0]))
+                    .to.emit(reporter, "Add")
+                    .withArgs(vault.address, other.address, hashItem(items[1]))
+                    .to.emit(reporter, "Add")
+                    .withArgs(vault.address, other.address, hashItem(items[2]))
+                    .to.emit(reporter, "Add")
+                    .withArgs(vault.address, other.address, hashItem(items[3]));
+            });
+
+            it("should not allow an address to add items to inventory with an invalid permit signature");
+            it("should allow an address to add items to inventory with a permit signature from the owner");
+        });
+
+        describe("remove", () => {
+            // before - mint some NFTs and register some inventory
+
+            it("should revert if attempting to remove zero items");
+            it("should revert if attempting to remove more items than the maximum");
+            it("should revert if the caller is not the vault's owner or approved");
+            it("should allow the vault owner to remove items from inventory");
+            it("should allow an approved address to remove items from inventory");
+            it("should not revert if a specified item is not registered in inventory");
+            it("should not allow an address to remove items from inventory with an invalid permit signature");
+            it("should allow an address to remove items from inventory with a permit signature from the owner");
+        });
+
+        describe("clear", () => {
+            // before - mint some NFTs and register some inventory
+
+            it("should revert if the vault's registered inventory is larger than the maximum items per update");
+            it("should revert if the caller is not the vault's owner or approved");
+            it("should allow the vault owner to clear inventory");
+            it("should allow an approved address to clear inventory");
+            it("should not allow an address to clear inventory with an invalid permit signature");
+            it("should allow an address to clear inventory with a permit signature from the owner");
+        });
+    });
+
+    describe("Verification", () => {
+        // Before - mint some NFTs and register some inventory
+
+        it("should verify all items in a vault's inventory are currently held");
+        it("should return false if all items in a vault's inventory are not owned by the vault");
+        it("should verify whether a specific item in a vault's inventory is currently held");
+        it("should revert if a specific item submitted for verification is not in the registered inventory");
+        it("should return false if a specific item in a vault's inventory is not owned by the vault");
+    });
+
+    describe("Enumeration", () => {
+        // Before - mint some NFTs and register some inventory
+
+        it("should enumerate all items in a vault, without checking staleness");
+        it("should enumerate all items in a vault, checking for staleness");
+        it("should revert on enumerateOrFail if inventory is stale");
+        it("should report all item hashes for a vault's inventory");
+        it("should report a specific item hash for a vault's inventory");
+        it("should report a specific item for a vault's inventory");
+    });
+
+    describe("Permissions", () => {
+        it("should not allow a user who is not owner or approved for a vault to set reporting approval");
+        it("should allow a vault owner to set reporting approval");
+        it("should allow a vault owner to remove all reporting approval");
+        it("should allow an approved vault address to set reporting approval");
+    });
+
+});

--- a/test/VaultInventoryReporter.ts
+++ b/test/VaultInventoryReporter.ts
@@ -228,6 +228,24 @@ describe("VaultInventoryReporter", () => {
                 ).to.be.revertedWith("VIR_NotApproved");
             });
 
+            it("should revert if trying to add a token with address 0", async () => {
+                const { reporter, user, vault } = ctx;
+
+                const item: Item = {
+                    itemType: ERC_20_ITEM_TYPE,
+                    tokenAddress: ZERO_ADDRESS,
+                    tokenId: 0,
+                    tokenAmount: amount20
+                };
+
+                const items = [item];
+
+                await expect(
+                    reporter.connect(user).add(vault.address, items)
+                ).to.be.revertedWith("VIR_InvalidRegistration");
+            });
+
+
             it("should revert if not enough ERC20 tokens are held by the vault", async () => {
                 const { reporter, user, vault, mockERC20 } = ctx;
 
@@ -782,7 +800,7 @@ describe("VaultInventoryReporter", () => {
             expect(await reporter.verify(vault.address)).to.be.true;
         });
 
-        it("should return false if all items in a vault's inventory are not owned by the vault", async () => {
+        it("should return false if an ERC721 cannot be verified", async () => {
             const { reporter, user, mockERC721, vault } = ctx;
 
             // Make sure verification succeeds
@@ -791,6 +809,48 @@ describe("VaultInventoryReporter", () => {
             // Move item out of vault
             await vault.connect(user).enableWithdraw();
             await vault.connect(user).withdrawERC721(mockERC721.address, id721, user.address);
+
+            // make sure verification fails
+            expect(await reporter.verify(vault.address)).to.be.false;
+        });
+
+        it("should return false if an ERC20 cannot be verified", async () => {
+            const { reporter, user, mockERC20, vault } = ctx;
+
+            // Make sure verification succeeds
+            expect(await reporter.verify(vault.address)).to.be.true;
+
+            // Move item out of vault
+            await vault.connect(user).enableWithdraw();
+            await vault.connect(user).withdrawERC20(mockERC20.address, user.address);
+
+            // make sure verification fails
+            expect(await reporter.verify(vault.address)).to.be.false;
+        });
+
+        it("should return false if an ERC1155 cannot be verified", async () => {
+            const { reporter, user, mockERC1155, vault } = ctx;
+
+            // Make sure verification succeeds
+            expect(await reporter.verify(vault.address)).to.be.true;
+
+            // Move item out of vault
+            await vault.connect(user).enableWithdraw();
+            await vault.connect(user).withdrawERC1155(mockERC1155.address, id1155, user.address);
+
+            // make sure verification fails
+            expect(await reporter.verify(vault.address)).to.be.false;
+        });
+
+        it("should return false if a punk cannot be verified", async () => {
+            const { reporter, user, punks, vault } = ctx;
+
+            // Make sure verification succeeds
+            expect(await reporter.verify(vault.address)).to.be.true;
+
+            // Move item out of vault
+            await vault.connect(user).enableWithdraw();
+            await vault.connect(user).withdrawPunk(punks.address, idPunk, user.address);
 
             // make sure verification fails
             expect(await reporter.verify(vault.address)).to.be.false;

--- a/test/VaultInventoryReporter.ts
+++ b/test/VaultInventoryReporter.ts
@@ -1219,6 +1219,11 @@ describe("VaultInventoryReporter", () => {
                 .withArgs(other.address, false);
 
             expect(await reporter.isGloballyApproved(other.address)).to.be.false;
+
+            // Make sure cannot perform reporting
+            await expect(
+                reporter.connect(other).add(vault.address, defaultItems)
+            ).to.be.revertedWith("VIR_NotApproved")
         });
     });
 

--- a/test/utils/eip712.ts
+++ b/test/utils/eip712.ts
@@ -19,12 +19,33 @@ export interface PermitData {
     deadline: BigNumberish;
 }
 
+export interface InventoryPermitData {
+    owner: string;
+    target: string;
+    vault: string;
+    nonce: BigNumberish;
+    deadline: BigNumberish;
+}
+
 const typedPermitData: TypeData = {
     types: {
         Permit: [
             { name: "owner", type: "address" },
             { name: "spender", type: "address" },
             { name: "tokenId", type: "uint256" },
+            { name: "nonce", type: "uint256" },
+            { name: "deadline", type: "uint256" },
+        ],
+    },
+    primaryType: "Permit" as const,
+};
+
+const typedInventoryPermitData: TypeData = {
+    types: {
+        Permit: [
+            { name: "owner", type: "address" },
+            { name: "target", type: "address" },
+            { name: "vault", type: "address" },
             { name: "nonce", type: "uint256" },
             { name: "deadline", type: "uint256" },
         ],
@@ -166,6 +187,25 @@ export async function createPermitSignature(
     signer: SignerWithAddress,
 ): Promise<ECDSASignature> {
     const data = buildData(verifyingContract, name, "1", permitData, typedPermitData);
+    const signature = await signer._signTypedData(data.domain, data.types, data.message);
+
+    return fromRpcSig(signature);
+}
+
+/**
+ * Create an EIP712 signature for an inventory permit
+ * @param verifyingContract The address of the contract that will be verifying this signature
+ * @param name The name of the contract that will be verifying this signature
+ * @param permitData the data of the permit to sign
+ * @param signer The EOA to create the signature
+ */
+export async function createInventoryPermitSignature(
+    verifyingContract: string,
+    name: string,
+    permitData: InventoryPermitData,
+    signer: SignerWithAddress,
+): Promise<ECDSASignature> {
+    const data = buildData(verifyingContract, name, "1", permitData, typedInventoryPermitData);
     const signature = await signer._signTypedData(data.domain, data.types, data.message);
 
     return fromRpcSig(signature);

--- a/test/utils/erc1155.ts
+++ b/test/utils/erc1155.ts
@@ -9,8 +9,14 @@ export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
  */
 export const mint = async (token: MockERC1155, to: Signer, amount: BigNumber): Promise<string> => {
     const address = await to.getAddress();
+    return mintToAddress(token, address, amount);
+};
 
-    const tx = await token.mint(address, amount);
+/**
+ * Mint tokens for `to`
+ */
+export const mintToAddress = async (token: MockERC1155, to: string, amount: BigNumber): Promise<string> => {
+    const tx = await token.mint(to, amount);
     const receipt = await tx.wait();
 
     if (receipt && receipt.events && receipt.events.length === 1 && receipt.events[0].args) {

--- a/test/utils/erc721.ts
+++ b/test/utils/erc721.ts
@@ -8,7 +8,15 @@ export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
  * Mint a token for `to`
  */
 export const mint = async (token: MockERC721, to: Signer): Promise<BigNumber> => {
-    const tx = await token.mint(await to.getAddress());
+    const address = await to.getAddress();
+    return mintToAddress(token, address);
+};
+
+/**
+ * Mint a token for `to`
+ */
+export const mintToAddress = async (token: MockERC721, to: string): Promise<BigNumber> => {
+    const tx = await token.mint(to);
     const receipt = await tx.wait();
 
     if (receipt && receipt.events && receipt.events.length === 1 && receipt.events[0].args) {


### PR DESCRIPTION
This PR adds three new contracts:
* `VaultInventoryReporter` contains a system of mappings for determining which items a vault holds, and how accurate the reporting is.
* `VaultDepositRouter` provides functions that allow users to deposit to vaults and report their deposits in inventory in a single transaction.
* `VaultOwnershipChecker` is a parent contract inherited by the two contracts above, for utility functions checking vault ownership.

Tests are written for both contracts, along with a deploy script.