### PR TITLE
(l-plus-fees): added collateral sale and pay later fees + corresponding tests

### DIFF
--- a/contracts/FeeController.sol
+++ b/contracts/FeeController.sol
@@ -26,11 +26,17 @@ contract FeeController is IFeeController, Ownable {
     ///      which drain principal.
     uint256 public constant MAX_ORIGINATION_FEE = 1000;
     uint256 public constant MAX_ROLLOVER_FEE = 500;
+    uint256 public constant MAX_COLLATERALSALE_FEE = 500;
+    uint256 public constant MAX_PAYLATER_FEE = 500;
 
     /// @dev Fee for origination - default is 0.5%
     uint256 private originationFee = 50;
     /// @dev Fee for rollovers - default is 0.1%
     uint256 private rolloverFee = 10;
+    /// @dev Fee for collateral sale - default is 0.0%
+    uint256 private collateralSaleFee = 0;
+    /// @dev Fee for pay later - default is 0.0%
+    uint256 private payLaterFee = 0;
 
     // ========================================= FEE SETTERS ===========================================
 
@@ -48,7 +54,7 @@ contract FeeController is IFeeController, Ownable {
     }
 
     /**
-     * @notice Set the origination fee to the given value. The caller
+     * @notice Set the rollover fee to the given value. The caller
      *         must be the owner of the contract.
      *
      * @param _rolloverFee          The new rollover fee, in bps.
@@ -58,6 +64,32 @@ contract FeeController is IFeeController, Ownable {
 
         rolloverFee = _rolloverFee;
         emit UpdateRolloverFee(_rolloverFee);
+    }
+
+    /**
+     * @notice Set the collateralSale fee to the given value. The caller
+     *         must be the owner of the contract.
+     *
+     * @param _collateralSaleFee     The new collateralSale fee, in bps.
+     */
+    function setCollateralSaleFee(uint256 _collateralSaleFee) external override onlyOwner {
+        if (_collateralSaleFee > MAX_COLLATERALSALE_FEE) revert FC_FeeTooLarge();
+
+        collateralSaleFee = _collateralSaleFee;
+        emit UpdateCollateralSaleFee(_collateralSaleFee);
+    }
+
+    /**
+     * @notice Set the payLater fee to the given value. The caller
+     *         must be the owner of the contract.
+     *
+     * @param _payLaterFee          The new payLater fee, in bps.
+     */
+    function setPayLaterFee(uint256 _payLaterFee) external override onlyOwner {
+        if (_payLaterFee > MAX_PAYLATER_FEE) revert FC_FeeTooLarge();
+
+        payLaterFee = _payLaterFee;
+        emit UpdatePayLaterFee(_payLaterFee);
     }
 
     // ========================================= FEE GETTERS ===========================================
@@ -72,11 +104,29 @@ contract FeeController is IFeeController, Ownable {
     }
 
     /**
-     * @notice Get the current origination fee in bps.
+     * @notice Get the current rollover fee in bps.
      *
      * @return rolloverFee       The current fee in bps.
      */
     function getRolloverFee() public view override returns (uint256) {
         return rolloverFee;
+    }
+
+    /**
+     * @notice Get the current collateralSale fee in bps.
+     *
+     * @return collateralSaleFee   The current fee in bps.
+     */
+    function getCollateralSaleFee() public view override returns (uint256) {
+        return collateralSaleFee;
+    }
+
+    /**
+     * @notice Get the current payLater fee in bps.
+     *
+     * @return payLaterFee   The current fee in bps.
+     */
+    function getPayLaterFee() public view override returns (uint256) {
+        return payLaterFee;
     }
 }

--- a/contracts/interfaces/IFeeController.sol
+++ b/contracts/interfaces/IFeeController.sol
@@ -7,6 +7,8 @@ interface IFeeController {
 
     event UpdateOriginationFee(uint256 _newFee);
     event UpdateRolloverFee(uint256 _newFee);
+    event UpdateCollateralSaleFee(uint256 _newFee);
+    event UpdatePayLaterFee(uint256 _newFee);
 
     // ================ Fee Setters =================
 
@@ -14,9 +16,17 @@ interface IFeeController {
 
     function setRolloverFee(uint256 _rolloverFee) external;
 
+    function setCollateralSaleFee(uint256 _collateralSaleFee) external;
+
+    function setPayLaterFee(uint256 _payLaterFee) external;
+
     // ================ Fee Getters =================
 
     function getOriginationFee() external view returns (uint256);
 
     function getRolloverFee() external view returns (uint256);
+
+    function getCollateralSaleFee() external view returns (uint256);
+
+    function getPayLaterFee() external view returns (uint256);
 }

--- a/test/FeeController.ts
+++ b/test/FeeController.ts
@@ -180,7 +180,7 @@ describe("FeeController", () => {
                 expect(payLaterFee).to.equal(0);
             });
 
-            it("returns updated collateralSale fee after set", async () => {
+            it("returns updated payLater fee after set", async () => {
                 const { feeController, user } = await loadFixture(fixture);
                 const newFee = 200;
 

--- a/test/FeeController.ts
+++ b/test/FeeController.ts
@@ -85,7 +85,7 @@ describe("FeeController", () => {
                 await expect(feeController.connect(user).setRolloverFee(10_000)).to.be.revertedWith("FC_FeeTooLarge");
             });
 
-            it("sets origination fee", async () => {
+            it("sets rollover fee", async () => {
                 const { feeController, user } = await loadFixture(fixture);
                 await expect(feeController.connect(user).setRolloverFee(123))
                     .to.emit(feeController, "UpdateRolloverFee")
@@ -108,6 +108,86 @@ describe("FeeController", () => {
 
                 const rolloverFee = await feeController.connect(user).getRolloverFee();
                 expect(rolloverFee).to.equal(newFee);
+            });
+        });
+
+        describe("setCollateralSaleFee", () => {
+            it("reverts if sender does not have admin role", async () => {
+                const { feeController, other } = await loadFixture(fixture);
+                await expect(feeController.connect(other).setCollateralSaleFee(1234)).to.be.revertedWith(
+                    "Ownable: caller is not the owner",
+                );
+            });
+
+            it("reverts if new fee is over the maximum", async () => {
+                const { feeController, user } = await loadFixture(fixture);
+                await expect(feeController.connect(user).setCollateralSaleFee(10_000)).to.be.revertedWith(
+                    "FC_FeeTooLarge",
+                );
+            });
+
+            it("sets collateralSale fee", async () => {
+                const { feeController, user } = await loadFixture(fixture);
+                await expect(feeController.connect(user).setCollateralSaleFee(123))
+                    .to.emit(feeController, "UpdateCollateralSaleFee")
+                    .withArgs(123);
+            });
+        });
+
+        describe("getCollateralSaleFee", () => {
+            it("initially returns 0.0%", async () => {
+                const { feeController, user } = await loadFixture(fixture);
+                const collateralSaleFee = await feeController.connect(user).getCollateralSaleFee();
+                expect(collateralSaleFee).to.equal(0);
+            });
+
+            it("returns updated collateralSale fee after set", async () => {
+                const { feeController, user } = await loadFixture(fixture);
+                const newFee = 200;
+
+                await feeController.connect(user).setCollateralSaleFee(newFee);
+
+                const collateralSaleFee = await feeController.connect(user).getCollateralSaleFee();
+                expect(collateralSaleFee).to.equal(newFee);
+            });
+        });
+
+        describe("setPayLaterFee", () => {
+            it("reverts if sender does not have admin role", async () => {
+                const { feeController, other } = await loadFixture(fixture);
+                await expect(feeController.connect(other).setPayLaterFee(1234)).to.be.revertedWith(
+                    "Ownable: caller is not the owner",
+                );
+            });
+
+            it("reverts if new fee is over the maximum", async () => {
+                const { feeController, user } = await loadFixture(fixture);
+                await expect(feeController.connect(user).setPayLaterFee(10_000)).to.be.revertedWith("FC_FeeTooLarge");
+            });
+
+            it("sets payLater fee", async () => {
+                const { feeController, user } = await loadFixture(fixture);
+                await expect(feeController.connect(user).setPayLaterFee(123))
+                    .to.emit(feeController, "UpdatePayLaterFee")
+                    .withArgs(123);
+            });
+        });
+
+        describe("getPayLaterFee", () => {
+            it("initially returns 0.0%", async () => {
+                const { feeController, user } = await loadFixture(fixture);
+                const payLaterFee = await feeController.connect(user).getPayLaterFee();
+                expect(payLaterFee).to.equal(0);
+            });
+
+            it("returns updated collateralSale fee after set", async () => {
+                const { feeController, user } = await loadFixture(fixture);
+                const newFee = 200;
+
+                await feeController.connect(user).setPayLaterFee(newFee);
+
+                const payLaterFee = await feeController.connect(user).getPayLaterFee();
+                expect(payLaterFee).to.equal(newFee);
             });
         });
     });


### PR DESCRIPTION
Added in the option to set fees for `CollateralSale` and `PayLater`.
The initial fee is currently set to zero and can be updated from the `market` contracts as needed.

Added corresponding tests.

Run test suite with:
`yarn test`